### PR TITLE
Fix text types, headers, and multiline request bodies

### DIFF
--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -92,7 +92,13 @@
 				"$id":"#/definitions/common/text",
 				"title":"Text",
 				"type":"string",
-				"pattern":"^.*$"
+				"pattern":".+"
+			},
+			"textblob":{
+				"$id":"#/definitions/common/textblob",
+				"title":"Blob",
+				"type":"string",
+				"pattern":"((.|\n)*)"
 			},
 			"positive_number":{
 				"$id":"#/definitions/common/positive_number",
@@ -605,10 +611,19 @@
 						},
 						"headers": {
 							"type": "array",
-							"items": { "$ref": "#/definitions/common/text" }
+							"items": {
+								"type": "object",
+								"properties": {
+									"/": {}
+								},
+								"patternProperties": {
+									".*": { "type": "string" }
+								},
+								"additionalProperties": false
+							}
 						},
 						"sla_profile": { "$ref": "#/definitions/common/text" },
-						"body": { "$ref": "#/definitions/common/text" },
+						"body": { "$ref": "#/definitions/common/textblob" },
 						"extractors": {
 							"type": "array",
 							"items": { "$ref": "#/definitions/user_paths/extractor" }


### PR DESCRIPTION
Why?

The current spec does not match what we need, specifically for request header specs and multi-line bodies (such as JSON posts).

What?

Update the schema to support the above allowed/required specs.

Testing

Validated locally using 'neoload validate ...' against full example at https://github.com/Neotys-Connect/neoload-as-code/tree/master/training/module4