### PR TITLE
Feature/load 38517 improve as code yaml for draft 2019

### DIFF
--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json-schema.org/draft/2019-09/schema",
-	"$id": "https://neotys.com/schemas/as-code/v3",
+	"$id": "https://neotys.com/schemas/as-code/v3.1",
 	"title": "JSON Schema for NeoLoad as-code files",
 	"fileMatch": [
 		"*.nl.yaml",
@@ -36,13 +36,17 @@
 			"minItems": 1,
 			"additionalProperties": false,
 			"items": {
-				"anyOf": [
-					{ "$ref": "#/definitions/variables/constant" },
-					{ "$ref": "#/definitions/variables/file" },
-					{ "$ref": "#/definitions/variables/counter" },
-					{ "$ref": "#/definitions/variables/random_number" },
-					{ "$ref": "#/definitions/variables/javascript" }
-				]
+				"type": "object",
+				"additionalProperties": false,
+				"minProperties": 1,
+				"maxProperties": 1,
+				"properties": {
+					"constant": { "$ref": "#/definitions/variables/constant" },
+					"file": { "$ref": "#/definitions/variables/file" },
+					"counter": { "$ref": "#/definitions/variables/counter" },
+					"random_number": { "$ref": "#/definitions/variables/random_number" },
+					"javascript": { "$ref": "#/definitions/variables/javascript" }
+				}
 			}
 		},
 		"servers": {

--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -21,7 +21,7 @@
 		"$schema": { "$ref": "#/definitions/common/full_url" },
 		"name": { "$ref": "#/definitions/common/name" },
 		"includes": {
-			"$id": "#root/includes",
+			"$anchor": "root-includes",
 			"title": "Includes",
 			"type": "array",
 			"minItems": 1,
@@ -29,7 +29,7 @@
 			"items": { "$ref": "#/definitions/common/text" }
 		},
 		"variables": {
-			"$id": "#root/variables",
+			"$anchor": "root-variables",
 			"title": "Variables",
 			"type": "array",
 			"additionalItems": false,
@@ -46,42 +46,42 @@
 			}
 		},
 		"servers": {
-			"$id": "#root/servers",
+			"$anchor": "root-servers",
 			"title": "Servers",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/server" }
 		},
 		"sla_profiles": {
-			"$id": "#root/sla_profiles",
+			"$anchor": "root-sla_profiles",
 			"title": "SLA Profiles",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/sla" }
 		},
 		"populations": {
-			"$id": "#root/populations",
+			"$anchor": "root-populations",
 			"title": "Populations",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/populations/population" }
 		},
 		"scenarios": {
-			"$id": "#root/scenarios",
+			"$anchor": "root-scenarios",
 			"title": "Scenarios",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/scenario" }
 		},
 		"user_paths": {
-			"$id": "#root/user_paths",
+			"$anchor": "root-user_paths",
 			"title": "User_paths",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/user_paths/user_path" }
 		},
 		"project_settings": {
-			"$id": "#root/project_settings",
+			"$anchor": "root-project_settings",
 			"title": "Neoload_Project_settings",
 			"type": "object",
 			"additionalProperties": false,
@@ -104,52 +104,52 @@
 	"definitions": {
 		"common": {
 			"text": {
-				"$id": "#/definitions/common/text",
+				"$anchor": "definitions-common-text",
 				"title": "Value",
 				"type": "string",
 				"pattern": "^.*$"
 			},
 			"textblob": {
-				"$id": "#/definitions/common/textblob",
+				"$anchor": "definitions-common-textblob",
 				"title": "Blob",
 				"type": "string",
 				"pattern": "((.|\n)*)"
 			},
 			"positive_number": {
-				"$id": "#/definitions/common/positive_number",
+				"$anchor": "definitions-common-positive_number",
 				"title": "Positive Number",
 				"type": "integer",
 				"minimum": 0
 			},
 			"duration": {
-				"$id": "#/definitions/common/duration",
+				"$anchor": "definitions-common-duration",
 				"title": "Duration",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/iterations" }]
 			},
 			"stop_after_options": {
-				"$id": "#/definitions/common/stop_after_options",
+				"$anchor": "definitions-common-stop_after_options",
 				"title": "variation_policy.stop_after values",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "type": "string", "enum": ["current_iteration"] }]
 			},
 			"start_after_options": {
-				"$id": "#/definitions/common/start_after",
+				"$anchor": "definitions-common-start_after",
 				"title": "Start after",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/text" }]
 			},
 			"time": {
-				"$id": "#/definitions/common/time",
+				"$anchor": "definitions-common-time",
 				"title": "Time",
 				"type": "string",
 				"pattern": "^((\\d{1,2}[hms]{1}){1,3})+$"
 			},
 			"iterations": {
-				"$id": "#/definitions/common/iterations",
+				"$anchor": "definitions-common-iterations",
 				"title": "Iterations",
 				"type": "string",
 				"pattern": "^(\\d+ iterations)$"
 			},
 			"conditions": {
-				"$id": "#/definitions/common/conditions",
+				"$anchor": "definitions-common-conditions",
 				"title": "Conditions list",
 				"type": "array",
 				"items": {
@@ -191,7 +191,7 @@
 		},
 		"variables": {
 			"generic": {
-				"$id": "#/definitions/variables/generic",
+				"$anchor": "definitions-variables-generic",
 				"type": "object",
 				"required": ["name"],
 				"properties": {
@@ -201,7 +201,7 @@
 				}
 			},
 			"constant": {
-				"$id": "#/definitions/variables/constant",
+				"$anchor": "definitions-variables-constant",
 				"title": "Constant",
 				"type": "object",
 				"required": ["value"],
@@ -216,7 +216,7 @@
 				"unevaluatedProperties": false
 			},
 			"file": {
-				"$id": "#/definitions/variables/file",
+				"$anchor": "definitions-variables-file",
 				"title": "File",
 				"type": "object",
 				"required": ["path"],
@@ -250,7 +250,7 @@
 				"unevaluatedProperties": false
 			},
 			"counter": {
-				"$id": "#/definitions/variables/counter",
+				"$anchor": "definitions-variables-counter",
 				"title": "Counter",
 				"type": "object",
 				"required": ["start", "end", "increment"],
@@ -275,7 +275,7 @@
 				"unevaluatedProperties": false
 			},
 			"random_number": {
-				"$id": "#/definitions/variables/random_number",
+				"$anchor": "definitions-variables-random_number",
 				"title": "Random Number",
 				"type": "object",
 				"required": ["min", "max"],
@@ -298,7 +298,7 @@
 				"unevaluatedProperties": false
 			},
 			"javascript": {
-				"$id": "#/definitions/variables/javascript",
+				"$anchor": "definitions-variables-javascript",
 				"title": "Javascript",
 				"type": "object",
 				"required": ["script"],
@@ -314,7 +314,7 @@
 			}
 		},
 		"server": {
-			"$id": "#/definitions/server",
+			"$anchor": "definitions-server",
 			"title": "Server",
 			"type": "object",
 			"required": ["name", "host"],
@@ -323,7 +323,7 @@
 				"name": { "$ref": "#/definitions/common/text" },
 				"host": { "$ref": "#/definitions/common/text" },
 				"scheme": {
-					"$id": "#root/servers/items/scheme",
+					"$anchor": "root-servers-items-scheme",
 					"type": "string",
 					"enum": ["http", "https"]
 				},
@@ -337,7 +337,7 @@
 		},
 		"authentication": {
 			"auth-generic": {
-				"$id": "#/definitions/authentication/auth-generic",
+				"$anchor": "definitions-authentication-auth-generic",
 				"type": "object",
 				"required": ["login", "password"],
 				"properties": {
@@ -346,7 +346,7 @@
 				}
 			},
 			"auth-generic-domain": {
-				"$id": "#/definitions/authentication/auth-generic-domain",
+				"$anchor": "definitions-authentication-auth-generic-domain",
 				"type": "object",
 				"allOf": [
 					{ "$ref": "#/definitions/authentication/auth-generic" },
@@ -358,7 +358,7 @@
 				]
 			},
 			"basic": {
-				"$id": "#/definitions/authentication/basic",
+				"$anchor": "definitions-authentication-basic",
 				"title": "Basic Authentication",
 				"type": "object",
 				"allOf": [
@@ -371,20 +371,20 @@
 				]
 			},
 			"ntlm": {
-				"$id": "#/definitions/authentication/ntlm",
+				"$anchor": "definitions-authentication-ntlm",
 				"title": "NTLM Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			},
 			"negotiate": {
-				"$id": "#/definitions/authentication/negotiate",
+				"$anchor": "definitions-authentication-negotiate",
 				"title": "Negotiate Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			}
 		},
 		"sla": {
-			"$id": "#/definitions/sla",
+			"$anchor": "definitions-sla",
 			"title": "SLA Profile",
 			"type": "object",
 			"required": ["name", "thresholds"],
@@ -392,7 +392,7 @@
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
 				"thresholds": {
-					"$id": "#/definitions/sla/thresholds",
+					"$anchor": "definitions-sla-thresholds",
 					"title": "Thresholds",
 					"type": "array",
 					"minItems": 1,
@@ -401,7 +401,7 @@
 				}
 			},
 			"threshold": {
-				"$id": "#/definitions/sla/threshold",
+				"$anchor": "definitions-sla-threshold",
 				"title": "Threshold",
 				"type": "string",
 				"pattern": "^(.*?)\\s(warn\\s(>=|==|<=|>|<))(?=\\s)(.*?)per\\s(test|interval)$"
@@ -409,7 +409,7 @@
 		},
 		"populations": {
 			"population": {
-				"$id": "#/definitions/population",
+				"$anchor": "definitions-population",
 				"title": "Population",
 				"type": "object",
 				"properties": {
@@ -433,7 +433,7 @@
 				}
 			},
 			"constant_load": {
-				"$id": "#/definitions/populations/constant_load",
+				"$anchor": "definitions-populations-constant_load",
 				"title": "Constant Load",
 				"type": "object",
 				"required": ["users"],
@@ -449,7 +449,7 @@
 				}
 			},
 			"rampup_load": {
-				"$id": "#/definitions/populations/rampup_load",
+				"$anchor": "definitions-populations-rampup_load",
 				"title": "Ramp-up Load",
 				"type": "object",
 				"required": ["min_users", "increment_users", "increment_every"],
@@ -469,7 +469,7 @@
 				"additionalProperties": false
 			},
 			"peaks_load": {
-				"$id": "#/definitions/populations/peaks_load",
+				"$anchor": "definitions-populations-peaks_load",
 				"title": "Peaks Load",
 				"type": "object",
 				"required": ["minimum", "maximum", "start"],
@@ -488,7 +488,7 @@
 				"additionalProperties": false
 			},
 			"peaks_phase": {
-				"$id": "#/definitions/populations/peaks_phase",
+				"$anchor": "definitions-populations-peaks_phase",
 				"title": "Peak Phase",
 				"type": "object",
 				"required": ["users", "duration"],
@@ -499,21 +499,21 @@
 			}
 		},
 		"scenario": {
-			"$id": "#/definitions/scenario",
+			"$anchor": "definitions-scenario",
 			"title": "Scenario",
 			"type": "object",
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
 				"populations": {
-					"$id": "#/definitions/scenario/populations",
+					"$anchor": "definitions-scenario-populations",
 					"title": "Scenario Populations",
 					"type": "array",
 					"minItems": 1,
 					"additionalItems": false,
 					"additionalProperties": false,
 					"items": {
-						"$id": "#/definitions/scenario/populations/items",
+						"$anchor": "definitions-scenario-populations-items",
 						"type": "object",
 						"required": ["name"],
 						"properties": {
@@ -528,7 +528,7 @@
 		},
 		"user_paths": {
 			"user_path": {
-				"$id": "#/definitions/user_paths/user_path",
+				"$anchor": "definitions-user_paths-user_path",
 				"title": "User Path",
 				"type": "object",
 				"required": ["name", "actions"],
@@ -545,7 +545,7 @@
 				}
 			},
 			"container": {
-				"$id": "#/definitions/user_paths/container",
+				"$anchor": "definitions-user_paths-container",
 				"title": "Containers",
 				"type": "object",
 				"required": ["steps"],
@@ -557,7 +557,7 @@
 				}
 			},
 			"steps": {
-				"$id": "#/definitions/user_paths/steps",
+				"$anchor": "definitions-user_paths-steps",
 				"title": "Steps",
 				"type": "array",
 				"minItems": 1,
@@ -580,7 +580,7 @@
 			},
 			"actions": {
 				"transaction": {
-					"$id": "#/definitions/user_paths/actions/transaction",
+					"$anchor": "definitions-user_paths-actions-transaction",
 					"name": "transaction",
 					"title": "Action: Transaction",
 					"type": "object",
@@ -594,7 +594,7 @@
 					"additionalProperties": false
 				},
 				"request": {
-					"$id": "#/definitions/user_paths/actions/request",
+					"$anchor": "definitions-user_paths-actions-request",
 					"title": "Action: HTTP/s Request",
 					"type": "object",
 					"required": ["url"],
@@ -627,19 +627,19 @@
 					}
 				},
 				"delay": {
-					"$id": "#/definitions/user_paths/actions/delay",
+					"$anchor": "definitions-user_paths-actions-delay",
 					"title": "Action: Delay",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"think_time": {
-					"$id": "#/definitions/user_paths/actions/think_time",
+					"$anchor": "definitions-user_paths-actions-think_time",
 					"title": "Action: Think Time",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"javascript": {
-					"$id": "#/definitions/user_paths/actions/javascript",
+					"$anchor": "definitions-user_paths-actions-javascript",
 					"title": "Action: Javascript",
 					"type": "object",
 					"required": ["name", "script"],
@@ -650,7 +650,7 @@
 					}
 				},
 				"if": {
-					"$id": "#/definitions/user_paths/actions/if",
+					"$anchor": "definitions-user_paths-actions-if",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["then"],
@@ -669,7 +669,7 @@
 					"additionalProperties": false
 				},
 				"while": {
-					"$id": "#/definitions/user_paths/actions/while",
+					"$anchor": "definitions-user_paths-actions-while",
 					"title": "Action: While",
 					"type": "object",
 					"required": ["steps"],
@@ -687,7 +687,7 @@
 					"additionalProperties": false
 				},
 				"loop": {
-					"$id": "#/definitions/user_paths/actions/loop",
+					"$anchor": "definitions-user_paths-actions-loop",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["count", "steps"],
@@ -700,7 +700,7 @@
 					"additionalProperties": false
 				},
 				"switch": {
-					"$id": "#/definitions/user_paths/actions/switch",
+					"$anchor": "definitions-user_paths-actions-switch",
 					"title": "Action: Switch",
 					"type": "object",
 					"required": ["value", "default"],
@@ -717,7 +717,7 @@
 					"additionalProperties": false
 				},
 				"custom_action": {
-					"$id": "#/definitions/user_paths/actions/custom_action",
+					"$anchor": "definitions-user_paths-actions-custom_action",
 					"title": "Action: Custom Action",
 					"type": "object",
 					"required": ["name", "type"],

--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
 	"$id": "https://neotys.com/schemas/as-code/v3",
 	"title": "JSON Schema for NeoLoad as-code files",
 	"fileMatch": [
@@ -193,10 +193,10 @@
 			"generic": {
 				"$id": "#/definitions/variables/generic",
 				"type": "object",
-				"xrequired": ["name"],
+				"required": ["name"],
 				"properties": {
 					"name": { "$ref": "#/definitions/common/name" },
-					"descrption": { "$ref": "#/definitions/common/text" },
+					"description": { "$ref": "#/definitions/common/text" },
 					"change_policy": { "$ref": "#/definitions/common/var_change_policy" }
 				}
 			},
@@ -204,7 +204,7 @@
 				"$id": "#/definitions/variables/constant",
 				"title": "Constant",
 				"type": "object",
-				"xrequired": ["value"],
+				"required": ["value"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -213,13 +213,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"file": {
 				"$id": "#/definitions/variables/file",
 				"title": "File",
 				"type": "object",
-				"xrequired": ["path"],
+				"required": ["path"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -247,13 +247,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"counter": {
 				"$id": "#/definitions/variables/counter",
 				"title": "Counter",
 				"type": "object",
-				"xrequired": ["start", "end", "increment"],
+				"required": ["start", "end", "increment"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -272,13 +272,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"random_number": {
 				"$id": "#/definitions/variables/random_number",
 				"title": "Random Number",
 				"type": "object",
-				"xrequired": ["min", "max"],
+				"required": ["min", "max"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -295,13 +295,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"javascript": {
 				"$id": "#/definitions/variables/javascript",
 				"title": "Javascript",
 				"type": "object",
-				"xrequired": ["script"],
+				"required": ["script"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -310,14 +310,14 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			}
 		},
 		"server": {
 			"$id": "#/definitions/server",
 			"title": "Server",
 			"type": "object",
-			"xrequired": ["name", "host"],
+			"required": ["name", "host"],
 			"additionalProperties": false,
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
@@ -339,7 +339,7 @@
 			"auth-generic": {
 				"$id": "#/definitions/authentication/auth-generic",
 				"type": "object",
-				"xrequired": ["login", "password"],
+				"required": ["login", "password"],
 				"properties": {
 					"login": { "$ref": "#/definitions/common/text" },
 					"password": { "$ref": "#/definitions/common/text" }
@@ -387,7 +387,7 @@
 			"$id": "#/definitions/sla",
 			"title": "SLA Profile",
 			"type": "object",
-			"xrequired": ["name", "thresholds"],
+			"required": ["name", "thresholds"],
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
@@ -642,7 +642,7 @@
 					"$id": "#/definitions/user_paths/actions/javascript",
 					"title": "Action: Javascript",
 					"type": "object",
-					"xrequired": ["name", "script"],
+					"required": ["name", "script"],
 					"properties": {
 						"name": { "$ref": "#/definitions/common/text" },
 						"description": { "$ref": "#/definitions/common/text" },
@@ -740,7 +740,7 @@
 			},
 			"extractor": {
 				"type": "object",
-				"xrequired": ["name"],
+				"required": ["name"],
 				"properties": {
 					"name": { "$ref": "#/definitions/common/text" },
 					"from": {


### PR DESCRIPTION
## Summary

Make the as-code JSON schema actually enforce what it claims to, and align it with how real projects are written.

## Changes

- Replace the non-standard, silently-neutralised `xrequired` / `x-d7nosupport-additionalProperties` keywords with the real JSON-Schema keywords `required` / `unevaluatedProperties: false`, so missing required fields and unknown/misspelled properties are actually caught. Bump `$schema` to Draft 2019-09 (needed for `unevaluatedProperties`).
- Fix the `descrption` typo (→ `description`) in the variable definition - the only occurrence in the repo.
- Replace every decorative, non-root `$id` (e.g. `"$id": "#root/includes"`) with `$anchor`. Draft 2019-09 treats a bare-fragment `$id` as a base-URI change for its subtree, breaking `#/definitions/...` pointer refs nested underneath (`PointerToNowhere`) - Draft-07 tolerated the same values as harmless plain-name anchors. `$anchor` keeps a named, human-readable identifier without touching resolution; existing `$ref`s are untouched.
- Fix `properties.variables.items`: it expected a flat object matching one of the variable-type schemas directly, but every real as-code project writes it wrapped under the type name (e.g. `variables: [{ constant: { name: ..., value: ... } }]`). Changed to an object with exactly one of the 5 type keys (`minProperties`/`maxProperties: 1`, `additionalProperties: false`), each still validated against the existing flat variable-type definitions. Bumped `$id` to `v3.1` since this is a breaking shape change relative to the schema already published as `v3`.

## Verified

- Schema stays valid JSON; `neoload-project` Java test suite unaffected (same 3 pre-existing, unrelated failures with or without these changes).
- Validated with the real `jsonschema` library (Draft 2019-09): a real multi-file as-code project (`as-code-full-syntax`, merged with its includes) now validates with **0 errors**; a project with a missing required field, an unknown property, and a missing required server field is correctly **rejected** with exactly those 3 errors.
- Confirmed the previous (unfixed) schema on `v3` would have silently accepted the same invalid project (0 errors) - proving these fixes close a real validation gap.