### PR TITLE
LOAD-38517 — Fix as-code v3.1 schema: strict validation + real variables shape

### DIFF
--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft/2019-09/schema",
 	"$id": "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/schema-v3.1/schemas/v3.1/as-code.schema.json",
 	"title": "JSON Schema for NeoLoad as-code files",
 	"fileMatch": [
@@ -26,7 +26,7 @@
 		},
 		"name": { "$ref": "#/definitions/common/name" },
 		"includes": {
-			"$id": "#root/includes",
+			"$anchor": "root-includes",
 			"title": "Includes",
 			"type": "array",
 			"minItems": 1,
@@ -34,67 +34,71 @@
 			"items": { "$ref": "#/definitions/common/text" }
 		},
 		"variables": {
-			"$id": "#root/variables",
+			"$anchor": "root-variables",
 			"title": "Variables",
 			"type": "array",
 			"additionalItems": false,
 			"minItems": 1,
 			"additionalProperties": false,
 			"items": {
-				"anyOf": [
-					{ "$ref": "#/definitions/variables/constant" },
-					{ "$ref": "#/definitions/variables/file" },
-					{ "$ref": "#/definitions/variables/counter" },
-					{ "$ref": "#/definitions/variables/random_number" },
-					{ "$ref": "#/definitions/variables/random_string" },
-					{ "$ref": "#/definitions/variables/password" },
-					{ "$ref": "#/definitions/variables/date" },
-					{ "$ref": "#/definitions/variables/current_date" },
-					{ "$ref": "#/definitions/variables/list" },
-					{ "$ref": "#/definitions/variables/sql" },
-					{ "$ref": "#/definitions/variables/random_uuid" },
-					{ "$ref": "#/definitions/variables/shared_queue" },
-					{ "$ref": "#/definitions/variables/javascript" }
-				]
+				"type": "object",
+				"additionalProperties": false,
+				"minProperties": 1,
+				"maxProperties": 1,
+				"properties": {
+					"constant": { "$ref": "#/definitions/variables/constant" },
+					"file": { "$ref": "#/definitions/variables/file" },
+					"counter": { "$ref": "#/definitions/variables/counter" },
+					"random_number": { "$ref": "#/definitions/variables/random_number" },
+					"random_string": { "$ref": "#/definitions/variables/random_string" },
+					"password": { "$ref": "#/definitions/variables/password" },
+					"date": { "$ref": "#/definitions/variables/date" },
+					"current_date": { "$ref": "#/definitions/variables/current_date" },
+					"list": { "$ref": "#/definitions/variables/list" },
+					"sql": { "$ref": "#/definitions/variables/sql" },
+					"random_uuid": { "$ref": "#/definitions/variables/random_uuid" },
+					"shared_queue": { "$ref": "#/definitions/variables/shared_queue" },
+					"javascript": { "$ref": "#/definitions/variables/javascript" }
+				}
 			}
 		},
 		"servers": {
-			"$id": "#root/servers",
+			"$anchor": "root-servers",
 			"title": "Servers",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/server" }
 		},
 		"sla_profiles": {
-			"$id": "#root/sla_profiles",
+			"$anchor": "root-sla_profiles",
 			"title": "SLA Profiles",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/sla" }
 		},
 		"populations": {
-			"$id": "#root/populations",
+			"$anchor": "root-populations",
 			"title": "Populations",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/populations/population" }
 		},
 		"scenarios": {
-			"$id": "#root/scenarios",
+			"$anchor": "root-scenarios",
 			"title": "Scenarios",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/scenario" }
 		},
 		"user_paths": {
-			"$id": "#root/user_paths",
+			"$anchor": "root-user_paths",
 			"title": "User_paths",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/user_paths/user_path" }
 		},
 		"frameworks": {
-			"$id": "#root/frameworks",
+			"$anchor": "root-frameworks",
 			"title": "Frameworks",
 			"type": "array",
 			"minItems": 1,
@@ -108,7 +112,7 @@
 			}
 		},
 		"project_settings": {
-			"$id": "#root/project_settings",
+			"$anchor": "root-project_settings",
 			"title": "Neoload_Project_settings",
 			"type": "object",
 			"additionalProperties": false,
@@ -131,52 +135,52 @@
 	"definitions": {
 		"common": {
 			"text": {
-				"$id": "#/definitions/common/text",
+				"$anchor": "definitions-common-text",
 				"title": "Value",
 				"type": "string",
 				"pattern": "^.*$"
 			},
 			"textblob": {
-				"$id": "#/definitions/common/textblob",
+				"$anchor": "definitions-common-textblob",
 				"title": "Blob",
 				"type": "string",
 				"pattern": "((.|\n)*)"
 			},
 			"positive_number": {
-				"$id": "#/definitions/common/positive_number",
+				"$anchor": "definitions-common-positive_number",
 				"title": "Positive Number",
 				"type": "integer",
 				"minimum": 0
 			},
 			"duration": {
-				"$id": "#/definitions/common/duration",
+				"$anchor": "definitions-common-duration",
 				"title": "Duration",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/iterations" }]
 			},
 			"stop_after_options": {
-				"$id": "#/definitions/common/stop_after_options",
+				"$anchor": "definitions-common-stop_after_options",
 				"title": "variation_policy.stop_after values",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "type": "string", "enum": ["current_iteration"] }]
 			},
 			"start_after_options": {
-				"$id": "#/definitions/common/start_after",
+				"$anchor": "definitions-common-start_after",
 				"title": "Start after",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/text" }]
 			},
 			"time": {
-				"$id": "#/definitions/common/time",
+				"$anchor": "definitions-common-time",
 				"title": "Time",
 				"type": "string",
 				"pattern": "^((\\d{1,2}[hms]{1}){1,3})+$"
 			},
 			"iterations": {
-				"$id": "#/definitions/common/iterations",
+				"$anchor": "definitions-common-iterations",
 				"title": "Iterations",
 				"type": "string",
 				"pattern": "^(\\d+ iterations)$"
 			},
 			"conditions": {
-				"$id": "#/definitions/common/conditions",
+				"$anchor": "definitions-common-conditions",
 				"title": "Conditions list",
 				"type": "array",
 				"items": {
@@ -218,20 +222,20 @@
 		},
 		"variables": {
 			"generic": {
-				"$id": "#/definitions/variables/generic",
+				"$anchor": "definitions-variables-generic",
 				"type": "object",
-				"xrequired": ["name"],
+				"required": ["name"],
 				"properties": {
 					"name": { "$ref": "#/definitions/common/name" },
-					"descrption": { "$ref": "#/definitions/common/text" },
+					"description": { "$ref": "#/definitions/common/text" },
 					"change_policy": { "$ref": "#/definitions/common/var_change_policy" }
 				}
 			},
 			"constant": {
-				"$id": "#/definitions/variables/constant",
+				"$anchor": "definitions-variables-constant",
 				"title": "Constant",
 				"type": "object",
-				"xrequired": ["value"],
+				"required": ["value"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -240,13 +244,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"file": {
-				"$id": "#/definitions/variables/file",
+				"$anchor": "definitions-variables-file",
 				"title": "File",
 				"type": "object",
-				"xrequired": ["path"],
+				"required": ["path"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -274,13 +278,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"counter": {
-				"$id": "#/definitions/variables/counter",
+				"$anchor": "definitions-variables-counter",
 				"title": "Counter",
 				"type": "object",
-				"xrequired": ["start", "end", "increment"],
+				"required": ["start", "end", "increment"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -299,13 +303,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"random_number": {
-				"$id": "#/definitions/variables/random_number",
+				"$anchor": "definitions-variables-random_number",
 				"title": "Random Number",
 				"type": "object",
-				"xrequired": ["min", "max"],
+				"required": ["min", "max"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -322,13 +326,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"random_string": {
-				"$id": "#/definitions/variables/random_string",
+				"$anchor": "definitions-variables-random_string",
 				"title": "Random String",
 				"type": "object",
-				"xrequired": ["min_length", "max_length"],
+				"required": ["min_length", "max_length"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -345,13 +349,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"password": {
-				"$id": "#/definitions/variables/password",
+				"$anchor": "definitions-variables-password",
 				"title": "Password",
 				"type": "object",
-				"xrequired": ["value"],
+				"required": ["value"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -360,13 +364,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"date": {
-				"$id": "#/definitions/variables/date",
+				"$anchor": "definitions-variables-date",
 				"title": "Date",
 				"type": "object",
-				"xrequired": ["pattern"],
+				"required": ["pattern"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -385,13 +389,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"current_date": {
-				"$id": "#/definitions/variables/current_date",
+				"$anchor": "definitions-variables-current_date",
 				"title": "Current Date",
 				"type": "object",
-				"xrequired": ["pattern"],
+				"required": ["pattern"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -409,13 +413,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"list": {
-				"$id": "#/definitions/variables/list",
+				"$anchor": "definitions-variables-list",
 				"title": "List",
 				"type": "object",
-				"xrequired": ["values"],
+				"required": ["values"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -434,13 +438,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"sql": {
-				"$id": "#/definitions/variables/sql",
+				"$anchor": "definitions-variables-sql",
 				"title": "SQL",
 				"type": "object",
-				"xrequired": ["query", "driver", "url"],
+				"required": ["query", "driver", "url"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -457,13 +461,13 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"javascript": {
-				"$id": "#/definitions/variables/javascript",
+				"$anchor": "definitions-variables-javascript",
 				"title": "Javascript",
 				"type": "object",
-				"xrequired": ["script"],
+				"required": ["script"],
 				"allOf": [
 					{ "$ref": "#/definitions/variables/generic" },
 					{
@@ -472,10 +476,10 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"random_uuid": {
-				"$id": "#/definitions/variables/random_uuid",
+				"$anchor": "definitions-variables-random_uuid",
 				"title": "Random UUID",
 				"type": "object",
 				"allOf": [
@@ -493,10 +497,10 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			},
 			"shared_queue": {
-				"$id": "#/definitions/variables/shared_queue",
+				"$anchor": "definitions-variables-shared_queue",
 				"title": "Shared Queue",
 				"type": "object",
 				"allOf": [
@@ -533,20 +537,20 @@
 						}
 					}
 				],
-				"x-d7nosupport-additionalProperties": false
+				"unevaluatedProperties": false
 			}
 		},
 		"server": {
-			"$id": "#/definitions/server",
+			"$anchor": "definitions-server",
 			"title": "Server",
 			"type": "object",
-			"xrequired": ["name", "host"],
+			"required": ["name", "host"],
 			"additionalProperties": false,
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"host": { "$ref": "#/definitions/common/text" },
 				"scheme": {
-					"$id": "#root/servers/items/scheme",
+					"$anchor": "root-servers-items-scheme",
 					"type": "string",
 					"enum": ["http", "https"]
 				},
@@ -560,16 +564,16 @@
 		},
 		"authentication": {
 			"auth-generic": {
-				"$id": "#/definitions/authentication/auth-generic",
+				"$anchor": "definitions-authentication-auth-generic",
 				"type": "object",
-				"xrequired": ["login", "password"],
+				"required": ["login", "password"],
 				"properties": {
 					"login": { "$ref": "#/definitions/common/text" },
 					"password": { "$ref": "#/definitions/common/text" }
 				}
 			},
 			"auth-generic-domain": {
-				"$id": "#/definitions/authentication/auth-generic-domain",
+				"$anchor": "definitions-authentication-auth-generic-domain",
 				"type": "object",
 				"allOf": [
 					{ "$ref": "#/definitions/authentication/auth-generic" },
@@ -581,7 +585,7 @@
 				]
 			},
 			"basic": {
-				"$id": "#/definitions/authentication/basic",
+				"$anchor": "definitions-authentication-basic",
 				"title": "Basic Authentication",
 				"type": "object",
 				"allOf": [
@@ -594,28 +598,28 @@
 				]
 			},
 			"ntlm": {
-				"$id": "#/definitions/authentication/ntlm",
+				"$anchor": "definitions-authentication-ntlm",
 				"title": "NTLM Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			},
 			"negotiate": {
-				"$id": "#/definitions/authentication/negotiate",
+				"$anchor": "definitions-authentication-negotiate",
 				"title": "Negotiate Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			}
 		},
 		"sla": {
-			"$id": "#/definitions/sla",
+			"$anchor": "definitions-sla",
 			"title": "SLA Profile",
 			"type": "object",
-			"xrequired": ["name", "thresholds"],
+			"required": ["name", "thresholds"],
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
 				"thresholds": {
-					"$id": "#/definitions/sla/thresholds",
+					"$anchor": "definitions-sla-thresholds",
 					"title": "Thresholds",
 					"type": "array",
 					"minItems": 1,
@@ -624,7 +628,7 @@
 				}
 			},
 			"threshold": {
-				"$id": "#/definitions/sla/threshold",
+				"$anchor": "definitions-sla-threshold",
 				"title": "Threshold",
 				"type": "string",
 				"pattern": "^(.*?)\\s(warn\\s(>=|==|<=|>|<))(?=\\s)(.*?)per\\s(test|interval)$"
@@ -632,7 +636,7 @@
 		},
 		"populations": {
 			"population": {
-				"$id": "#/definitions/population",
+				"$anchor": "definitions-population",
 				"title": "Population",
 				"type": "object",
 				"properties": {
@@ -656,7 +660,7 @@
 				}
 			},
 			"constant_load": {
-				"$id": "#/definitions/populations/constant_load",
+				"$anchor": "definitions-populations-constant_load",
 				"title": "Constant Load",
 				"type": "object",
 				"required": ["users"],
@@ -672,7 +676,7 @@
 				}
 			},
 			"rampup_load": {
-				"$id": "#/definitions/populations/rampup_load",
+				"$anchor": "definitions-populations-rampup_load",
 				"title": "Ramp-up Load",
 				"type": "object",
 				"required": ["min_users", "increment_users", "increment_every"],
@@ -692,7 +696,7 @@
 				"additionalProperties": false
 			},
 			"peaks_load": {
-				"$id": "#/definitions/populations/peaks_load",
+				"$anchor": "definitions-populations-peaks_load",
 				"title": "Peaks Load",
 				"type": "object",
 				"required": ["minimum", "maximum", "start"],
@@ -711,7 +715,7 @@
 				"additionalProperties": false
 			},
 			"peaks_phase": {
-				"$id": "#/definitions/populations/peaks_phase",
+				"$anchor": "definitions-populations-peaks_phase",
 				"title": "Peak Phase",
 				"type": "object",
 				"required": ["users", "duration"],
@@ -721,7 +725,7 @@
 				}
 			},
 			"custom_load": {
-				"$id": "#/definitions/populations/custom_load",
+				"$anchor": "definitions-populations-custom_load",
 				"title": "Custom Load",
 				"type": "object",
 				"required": ["steps"],
@@ -738,7 +742,7 @@
 				"additionalProperties": false
 			},
 			"custom_policy_step": {
-				"$id": "#/definitions/populations/custom_policy_step",
+				"$anchor": "definitions-populations-custom_policy_step",
 				"title": "Custom Policy Step",
 				"type": "object",
 				"required": ["when", "users"],
@@ -750,7 +754,7 @@
 			}
 		},
 		"scenario": {
-			"$id": "#/definitions/scenario",
+			"$anchor": "definitions-scenario",
 			"title": "Scenario",
 			"type": "object",
 			"properties": {
@@ -772,14 +776,14 @@
 					"items": { "$ref": "#/definitions/scenario/rendezvous_policy" }
 				},
 				"populations": {
-					"$id": "#/definitions/scenario/populations",
+					"$anchor": "definitions-scenario-populations",
 					"title": "Scenario Populations",
 					"type": "array",
 					"minItems": 1,
 					"additionalItems": false,
 					"additionalProperties": false,
 					"items": {
-						"$id": "#/definitions/scenario/populations/items",
+						"$anchor": "definitions-scenario-populations-items",
 						"type": "object",
 						"required": ["name"],
 						"properties": {
@@ -793,7 +797,7 @@
 				}
 			},
 			"apm": {
-				"$id": "#/definitions/scenario/apm",
+				"$anchor": "definitions-scenario-apm",
 				"title": "APM Configuration",
 				"type": "object",
 				"properties": {
@@ -809,7 +813,7 @@
 				"additionalProperties": false
 			},
 			"dynatrace_anomaly_rule": {
-				"$id": "#/definitions/scenario/dynatrace_anomaly_rule",
+				"$anchor": "definitions-scenario-dynatrace_anomaly_rule",
 				"title": "Dynatrace Anomaly Rule",
 				"type": "object",
 				"required": ["metric_id", "operator", "value", "severity"],
@@ -828,7 +832,7 @@
 				"additionalProperties": false
 			},
 			"monitoring": {
-				"$id": "#/definitions/scenario/monitoring",
+				"$anchor": "definitions-scenario-monitoring",
 				"title": "Monitoring Parameters",
 				"type": "object",
 				"properties": {
@@ -838,7 +842,7 @@
 				"additionalProperties": false
 			},
 			"rendezvous_policy": {
-				"$id": "#/definitions/scenario/rendezvous_policy",
+				"$anchor": "definitions-scenario-rendezvous_policy",
 				"title": "Rendezvous Policy",
 				"type": "object",
 				"required": ["name"],
@@ -852,7 +856,7 @@
 		},
 		"user_paths": {
 			"user_path": {
-				"$id": "#/definitions/user_paths/user_path",
+				"$anchor": "definitions-user_paths-user_path",
 				"title": "User Path",
 				"type": "object",
 				"required": ["name", "actions"],
@@ -869,7 +873,7 @@
 				}
 			},
 			"container": {
-				"$id": "#/definitions/user_paths/container",
+				"$anchor": "definitions-user_paths-container",
 				"title": "Containers",
 				"type": "object",
 				"required": ["steps"],
@@ -890,7 +894,7 @@
 				}
 			},
 			"steps": {
-				"$id": "#/definitions/user_paths/steps",
+				"$anchor": "definitions-user_paths-steps",
 				"title": "Steps",
 				"type": "array",
 				"minItems": 1,
@@ -922,7 +926,7 @@
 			},
 			"actions": {
 				"transaction": {
-					"$id": "#/definitions/user_paths/actions/transaction",
+					"$anchor": "definitions-user_paths-actions-transaction",
 					"name": "transaction",
 					"title": "Action: Transaction",
 					"type": "object",
@@ -945,7 +949,7 @@
 					"additionalProperties": false
 				},
 				"http_page": {
-					"$id": "#/definitions/user_paths/actions/http_page",
+					"$anchor": "definitions-user_paths-actions-http_page",
 					"name": "http_page",
 					"title": "Action: HTTP Page",
 					"type": "object",
@@ -975,7 +979,7 @@
 					"additionalProperties": false
 				},
 				"request": {
-					"$id": "#/definitions/user_paths/actions/request",
+					"$anchor": "definitions-user_paths-actions-request",
 					"title": "Action: HTTP/s Request",
 					"type": "object",
 					"required": ["url"],
@@ -1027,22 +1031,22 @@
 					}
 				},
 				"delay": {
-					"$id": "#/definitions/user_paths/actions/delay",
+					"$anchor": "definitions-user_paths-actions-delay",
 					"title": "Action: Delay",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"think_time": {
-					"$id": "#/definitions/user_paths/actions/think_time",
+					"$anchor": "definitions-user_paths-actions-think_time",
 					"title": "Action: Think Time",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"javascript": {
-					"$id": "#/definitions/user_paths/actions/javascript",
+					"$anchor": "definitions-user_paths-actions-javascript",
 					"title": "Action: Javascript",
 					"type": "object",
-					"xrequired": ["name", "script"],
+					"required": ["name", "script"],
 					"properties": {
 						"name": { "$ref": "#/definitions/common/text" },
 						"description": { "$ref": "#/definitions/common/text" },
@@ -1050,7 +1054,7 @@
 					}
 				},
 				"if": {
-					"$id": "#/definitions/user_paths/actions/if",
+					"$anchor": "definitions-user_paths-actions-if",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["then"],
@@ -1069,7 +1073,7 @@
 					"additionalProperties": false
 				},
 				"while": {
-					"$id": "#/definitions/user_paths/actions/while",
+					"$anchor": "definitions-user_paths-actions-while",
 					"title": "Action: While",
 					"type": "object",
 					"required": ["steps"],
@@ -1087,7 +1091,7 @@
 					"additionalProperties": false
 				},
 				"loop": {
-					"$id": "#/definitions/user_paths/actions/loop",
+					"$anchor": "definitions-user_paths-actions-loop",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["count", "steps"],
@@ -1100,7 +1104,7 @@
 					"additionalProperties": false
 				},
 				"switch": {
-					"$id": "#/definitions/user_paths/actions/switch",
+					"$anchor": "definitions-user_paths-actions-switch",
 					"title": "Action: Switch",
 					"type": "object",
 					"required": ["value", "default"],
@@ -1117,7 +1121,7 @@
 					"additionalProperties": false
 				},
 				"custom_action": {
-					"$id": "#/definitions/user_paths/actions/custom_action",
+					"$anchor": "definitions-user_paths-actions-custom_action",
 					"title": "Action: Custom Action",
 					"type": "object",
 					"required": ["name", "type"],
@@ -1138,13 +1142,13 @@
 					"additionalProperties": false
 				},
 				"go_to_next_iteration": {
-					"$id": "#/definitions/user_paths/actions/go_to_next_iteration",
+					"$anchor": "definitions-user_paths-actions-go_to_next_iteration",
 					"title": "Action: Go to next iteration",
 					"type": "object",
 					"additionalProperties": false
 				},
 				"stop_vu": {
-					"$id": "#/definitions/user_paths/actions/stop_vu",
+					"$anchor": "definitions-user_paths-actions-stop_vu",
 					"title": "Action: Stop Virtual User",
 					"type": "object",
 					"properties": {
@@ -1156,7 +1160,7 @@
 					"additionalProperties": false
 				},
 				"fork": {
-					"$id": "#/definitions/user_paths/actions/fork",
+					"$anchor": "definitions-user_paths-actions-fork",
 					"title": "Action: Fork",
 					"type": "object",
 					"required": ["steps"],
@@ -1172,7 +1176,7 @@
 					"additionalProperties": false
 				},
 				"wait_until": {
-					"$id": "#/definitions/user_paths/actions/wait_until",
+					"$anchor": "definitions-user_paths-actions-wait_until",
 					"title": "Action: Wait Until",
 					"type": "object",
 					"required": ["conditions"],
@@ -1190,7 +1194,7 @@
 					"additionalProperties": false
 				},
 				"variable_modifier": {
-					"$id": "#/definitions/user_paths/actions/variable_modifier",
+					"$anchor": "definitions-user_paths-actions-variable_modifier",
 					"title": "Action: Variable Modifier",
 					"type": "object",
 					"required": ["mode"],
@@ -1214,7 +1218,7 @@
 					"additionalProperties": false
 				},
 				"debug_logger": {
-					"$id": "#/definitions/user_paths/actions/debug_logger",
+					"$anchor": "definitions-user_paths-actions-debug_logger",
 					"title": "Action: Debug Logger",
 					"type": "object",
 					"required": ["text"],
@@ -1225,7 +1229,7 @@
 					"additionalProperties": false
 				},
 				"rendezvous": {
-					"$id": "#/definitions/user_paths/actions/rendezvous",
+					"$anchor": "definitions-user_paths-actions-rendezvous",
 					"title": "Action: Rendezvous",
 					"type": "object",
 					"required": ["name"],
@@ -1236,7 +1240,7 @@
 					"additionalProperties": false
 				},
 				"try_catch": {
-					"$id": "#/definitions/user_paths/actions/try_catch",
+					"$anchor": "definitions-user_paths-actions-try_catch",
 					"title": "Action: Try Catch",
 					"type": "object",
 					"required": ["try"],
@@ -1256,7 +1260,7 @@
 			},
 			"extractor": {
 				"type": "object",
-				"xrequired": ["name"],
+				"required": ["name"],
 				"properties": {
 					"name": { "$ref": "#/definitions/common/text" },
 					"from": {
@@ -1291,7 +1295,7 @@
 				}
 			},
 			"content_assertion": {
-				"$id": "#/definitions/user_paths/content_assertion",
+				"$anchor": "definitions-user_paths-content_assertion",
 				"title": "Content Assertion",
 				"type": "object",
 				"properties": {
@@ -1311,7 +1315,7 @@
 				"additionalProperties": false
 			},
 			"part": {
-				"$id": "#/definitions/user_paths/part",
+				"$anchor": "definitions-user_paths-part",
 				"title": "Multipart Part",
 				"type": "object",
 				"required": ["name"],
@@ -1327,7 +1331,7 @@
 				"additionalProperties": false
 			},
 			"size_assertion": {
-				"$id": "#/definitions/user_paths/size_assertion",
+				"$anchor": "definitions-user_paths-size_assertion",
 				"title": "Size Assertion",
 				"type": "object",
 				"required": ["operator", "value"],
@@ -1345,7 +1349,7 @@
 				"additionalProperties": false
 			},
 			"duration_assertion": {
-				"$id": "#/definitions/user_paths/duration_assertion",
+				"$anchor": "definitions-user_paths-duration_assertion",
 				"title": "Duration Assertion",
 				"type": "object",
 				"required": ["value"],
@@ -1359,7 +1363,7 @@
 				"additionalProperties": false
 			},
 			"assertion_wrapper": {
-				"$id": "#/definitions/user_paths/assertion_wrapper",
+				"$anchor": "definitions-user_paths-assertion_wrapper",
 				"title": "Assertion (wrapped)",
 				"type": "object",
 				"properties": {
@@ -1397,7 +1401,7 @@
 		},
 		"framework": {
 			"builtin_framework_ref": {
-				"$id": "#/definitions/framework/builtin_framework_ref",
+				"$anchor": "definitions-framework-builtin_framework_ref",
 				"title": "Built-in Framework Reference",
 				"type": "object",
 				"required": ["name"],
@@ -1412,7 +1416,7 @@
 				"additionalProperties": false
 			},
 			"custom_framework": {
-				"$id": "#/definitions/framework/custom_framework",
+				"$anchor": "definitions-framework-custom_framework",
 				"title": "Custom Framework",
 				"type": "object",
 				"required": ["name", "parameters"],
@@ -1432,7 +1436,7 @@
 				"additionalProperties": false
 			},
 			"dynamic_parameter": {
-				"$id": "#/definitions/framework/dynamic_parameter",
+				"$anchor": "definitions-framework-dynamic_parameter",
 				"title": "Dynamic Parameter",
 				"type": "object",
 				"required": ["name"],

--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -611,21 +611,26 @@
 					"xcomments": {
 						"value": "why do we need the substructure 'name' to denote a string list?"
 					},
-					"user_paths": {
-						"type": "array",
-						"minItems": 1,
-						"additionalProperties": false,
-						"additionalItems": false,
-						"items": {
-							"type": "object",
-							"required": ["name"],
-							"additionalProperties": false,
-							"properties": {
-								"name": { "$ref": "#/definitions/common/text" }
+					"user_paths": {                                                                                                                                                                                                           
+						"type": "array",                                                                                                                                                                                                          
+						"minItems": 1,                                                                                                                                                                                                            
+						"additionalItems": false,                                                                                                                                                                                                 
+						"items": {                                                                                                                                                                                                                
+							"type": "object",                                                                                                                                                                                                       
+							"required": ["name"],                                                                                                                                                                                                   
+							"additionalProperties": false,                                                                                                                                                                                          
+							"properties": {                                                                                                                                                                                                         
+								"name": { "$ref": "#/definitions/common/text" },                                                                                                                                                                      
+								"distribution": {                                                                                                                                                                                                     
+									"anyOf": [                                                                                                                                                                                                          
+										{ "type": "string", "pattern": "^\\d{1,3}(\\.\\d)?%?$" },                                                                                                                                                         
+										{ "type": "number", "minimum": 0, "maximum": 100 }                                                                                                                                                                
+									]
+								}
 							}
 						}
 					}
-				}
+				}	
 			},
 			"constant_load": {
 				"title": "Constant Load",

--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -96,6 +96,8 @@
 			"minItems": 1,
 			"items": {
 				"type": "object",
+				"minProperties": 1,
+				"maxProperties": 1,
 				"properties": {
 					"builtin": { "$ref": "#/definitions/framework/builtin_framework_ref" },
 					"custom": { "$ref": "#/definitions/framework/custom_framework" }
@@ -525,7 +527,7 @@
 				},
 				"basic_authentication": { "$ref": "#/definitions/authentication/basic" },
 				"ntlm_authentication": { "$ref": "#/definitions/authentication/ntlm" },
-				"negotiate_authentication": { "$ref": "#/definitions/authentication/basic" }
+				"negotiate_authentication": { "$ref": "#/definitions/authentication/negotiate" }
 			}
 		},
 		"authentication": {
@@ -546,7 +548,8 @@
 							"domain": { "$ref": "#/definitions/common/text" }
 						}
 					}
-				]
+				],
+				"unevaluatedProperties": false
 			},
 			"basic": {
 				"title": "Basic Authentication",
@@ -558,23 +561,27 @@
 							"realm": { "$ref": "#/definitions/common/text" }
 						}
 					}
-				]
+				],
+				"unevaluatedProperties": false
 			},
 			"ntlm": {
 				"title": "NTLM Authentication",
 				"type": "object",
-				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
+				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }],
+				"unevaluatedProperties": false
 			},
 			"negotiate": {
 				"title": "Negotiate Authentication",
 				"type": "object",
-				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
+				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }],
+				"unevaluatedProperties": false
 			}
 		},
 		"sla": {
 			"title": "SLA Profile",
 			"type": "object",
 			"required": ["name", "thresholds"],
+			"additionalProperties": false,
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
@@ -596,6 +603,8 @@
 			"population": {
 				"title": "Population",
 				"type": "object",
+				"required": ["name"],
+				"additionalProperties": false,
 				"properties": {
 					"name": { "$ref": "#/definitions/common/text" },
 					"description": { "$ref": "#/definitions/common/text" },
@@ -609,6 +618,8 @@
 						"additionalItems": false,
 						"items": {
 							"type": "object",
+							"required": ["name"],
+							"additionalProperties": false,
 							"properties": {
 								"name": { "$ref": "#/definitions/common/text" }
 							}
@@ -620,6 +631,7 @@
 				"title": "Constant Load",
 				"type": "object",
 				"required": ["users"],
+				"additionalProperties": false,
 				"properties": {
 					"duration": { "$ref": "#/definitions/common/duration" },
 					"start_after": { "$ref": "#/definitions/common/start_after_options" },
@@ -672,6 +684,7 @@
 				"title": "Peak Phase",
 				"type": "object",
 				"required": ["users", "duration"],
+				"additionalProperties": false,
 				"properties": {
 					"users": { "$ref": "#/definitions/common/positive_number" },
 					"duration": { "$ref": "#/definitions/common/duration" }
@@ -707,6 +720,8 @@
 		"scenario": {
 			"title": "Scenario",
 			"type": "object",
+			"required": ["name"],
+			"additionalProperties": false,
 			"properties": {
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
@@ -734,6 +749,7 @@
 					"items": {
 						"type": "object",
 						"required": ["name"],
+						"additionalProperties": false,
 						"properties": {
 							"name": { "$ref": "#/definitions/common/text" },
 							"constant_load": { "$ref": "#/definitions/populations/constant_load" },
@@ -803,6 +819,7 @@
 				"title": "User Path",
 				"type": "object",
 				"required": ["name", "actions"],
+				"additionalProperties": false,
 				"properties": {
 					"name": { "$ref": "#/definitions/common/text" },
 					"description": { "$ref": "#/definitions/common/text" },
@@ -819,6 +836,7 @@
 				"title": "Containers",
 				"type": "object",
 				"required": ["steps"],
+				"additionalProperties": false,
 				"properties": {
 					"sla_profile": {
 						"type": "string"
@@ -841,6 +859,8 @@
 				"minItems": 1,
 				"items": {
 					"type": "object",
+					"minProperties": 1,
+					"maxProperties": 1,
 					"properties": {
 						"transaction": { "$ref": "#/definitions/user_paths/actions/transaction" },
 						"request": { "$ref": "#/definitions/user_paths/actions/request" },
@@ -921,6 +941,7 @@
 					"title": "Action: HTTP/s Request",
 					"type": "object",
 					"required": ["url"],
+					"additionalProperties": false,
 					"properties": {
 						"name": { "$ref": "#/definitions/common/text" },
 						"url": { "$ref": "#/definitions/common/text" },
@@ -982,6 +1003,7 @@
 					"title": "Action: Javascript",
 					"type": "object",
 					"required": ["name", "script"],
+					"additionalProperties": false,
 					"properties": {
 						"name": { "$ref": "#/definitions/common/text" },
 						"description": { "$ref": "#/definitions/common/text" },
@@ -1183,6 +1205,7 @@
 			"extractor": {
 				"type": "object",
 				"required": ["name"],
+				"additionalProperties": false,
 				"properties": {
 					"name": { "$ref": "#/definitions/common/text" },
 					"from": {
@@ -1283,6 +1306,8 @@
 			"assertion_wrapper": {
 				"title": "Assertion (wrapped)",
 				"type": "object",
+				"minProperties": 1,
+				"maxProperties": 1,
 				"properties": {
 					"content": { "$ref": "#/definitions/user_paths/content_assertion" },
 					"size": { "$ref": "#/definitions/user_paths/size_assertion" },

--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -949,7 +949,7 @@
 						"server": { "$ref": "#/definitions/common/text" },
 						"method": {
 							"type": "string",
-							"enum": ["GET", "POST", "HEAD", "PUT", "DELETE", "OPTIONS", "TRACE", "CUSTOM"]
+							"default": "GET"
 						},
 						"headers": {
 							"type": "array",

--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -838,6 +838,7 @@
 				"required": ["steps"],
 				"additionalProperties": false,
 				"properties": {
+					"description": { "$ref": "#/definitions/common/text" },
 					"sla_profile": {
 						"type": "string"
 					},

--- a/schemas/v3.1/as-code.schema.json
+++ b/schemas/v3.1/as-code.schema.json
@@ -26,7 +26,6 @@
 		},
 		"name": { "$ref": "#/definitions/common/name" },
 		"includes": {
-			"$anchor": "root-includes",
 			"title": "Includes",
 			"type": "array",
 			"minItems": 1,
@@ -34,7 +33,6 @@
 			"items": { "$ref": "#/definitions/common/text" }
 		},
 		"variables": {
-			"$anchor": "root-variables",
 			"title": "Variables",
 			"type": "array",
 			"additionalItems": false,
@@ -63,42 +61,36 @@
 			}
 		},
 		"servers": {
-			"$anchor": "root-servers",
 			"title": "Servers",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/server" }
 		},
 		"sla_profiles": {
-			"$anchor": "root-sla_profiles",
 			"title": "SLA Profiles",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/sla" }
 		},
 		"populations": {
-			"$anchor": "root-populations",
 			"title": "Populations",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/populations/population" }
 		},
 		"scenarios": {
-			"$anchor": "root-scenarios",
 			"title": "Scenarios",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/scenario" }
 		},
 		"user_paths": {
-			"$anchor": "root-user_paths",
 			"title": "User_paths",
 			"type": "array",
 			"minItems": 1,
 			"items": { "$ref": "#/definitions/user_paths/user_path" }
 		},
 		"frameworks": {
-			"$anchor": "root-frameworks",
 			"title": "Frameworks",
 			"type": "array",
 			"minItems": 1,
@@ -112,7 +104,6 @@
 			}
 		},
 		"project_settings": {
-			"$anchor": "root-project_settings",
 			"title": "Neoload_Project_settings",
 			"type": "object",
 			"additionalProperties": false,
@@ -135,52 +126,43 @@
 	"definitions": {
 		"common": {
 			"text": {
-				"$anchor": "definitions-common-text",
 				"title": "Value",
 				"type": "string",
 				"pattern": "^.*$"
 			},
 			"textblob": {
-				"$anchor": "definitions-common-textblob",
 				"title": "Blob",
 				"type": "string",
 				"pattern": "((.|\n)*)"
 			},
 			"positive_number": {
-				"$anchor": "definitions-common-positive_number",
 				"title": "Positive Number",
 				"type": "integer",
 				"minimum": 0
 			},
 			"duration": {
-				"$anchor": "definitions-common-duration",
 				"title": "Duration",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/iterations" }]
 			},
 			"stop_after_options": {
-				"$anchor": "definitions-common-stop_after_options",
 				"title": "variation_policy.stop_after values",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "type": "string", "enum": ["current_iteration"] }]
 			},
 			"start_after_options": {
-				"$anchor": "definitions-common-start_after",
 				"title": "Start after",
 				"anyOf": [{ "$ref": "#/definitions/common/time" }, { "$ref": "#/definitions/common/text" }]
 			},
 			"time": {
-				"$anchor": "definitions-common-time",
 				"title": "Time",
 				"type": "string",
 				"pattern": "^((\\d{1,2}[hms]{1}){1,3})+$"
 			},
 			"iterations": {
-				"$anchor": "definitions-common-iterations",
 				"title": "Iterations",
 				"type": "string",
 				"pattern": "^(\\d+ iterations)$"
 			},
 			"conditions": {
-				"$anchor": "definitions-common-conditions",
 				"title": "Conditions list",
 				"type": "array",
 				"items": {
@@ -222,7 +204,6 @@
 		},
 		"variables": {
 			"generic": {
-				"$anchor": "definitions-variables-generic",
 				"type": "object",
 				"required": ["name"],
 				"properties": {
@@ -232,7 +213,6 @@
 				}
 			},
 			"constant": {
-				"$anchor": "definitions-variables-constant",
 				"title": "Constant",
 				"type": "object",
 				"required": ["value"],
@@ -247,7 +227,6 @@
 				"unevaluatedProperties": false
 			},
 			"file": {
-				"$anchor": "definitions-variables-file",
 				"title": "File",
 				"type": "object",
 				"required": ["path"],
@@ -281,7 +260,6 @@
 				"unevaluatedProperties": false
 			},
 			"counter": {
-				"$anchor": "definitions-variables-counter",
 				"title": "Counter",
 				"type": "object",
 				"required": ["start", "end", "increment"],
@@ -306,7 +284,6 @@
 				"unevaluatedProperties": false
 			},
 			"random_number": {
-				"$anchor": "definitions-variables-random_number",
 				"title": "Random Number",
 				"type": "object",
 				"required": ["min", "max"],
@@ -329,7 +306,6 @@
 				"unevaluatedProperties": false
 			},
 			"random_string": {
-				"$anchor": "definitions-variables-random_string",
 				"title": "Random String",
 				"type": "object",
 				"required": ["min_length", "max_length"],
@@ -352,7 +328,6 @@
 				"unevaluatedProperties": false
 			},
 			"password": {
-				"$anchor": "definitions-variables-password",
 				"title": "Password",
 				"type": "object",
 				"required": ["value"],
@@ -367,7 +342,6 @@
 				"unevaluatedProperties": false
 			},
 			"date": {
-				"$anchor": "definitions-variables-date",
 				"title": "Date",
 				"type": "object",
 				"required": ["pattern"],
@@ -392,7 +366,6 @@
 				"unevaluatedProperties": false
 			},
 			"current_date": {
-				"$anchor": "definitions-variables-current_date",
 				"title": "Current Date",
 				"type": "object",
 				"required": ["pattern"],
@@ -416,7 +389,6 @@
 				"unevaluatedProperties": false
 			},
 			"list": {
-				"$anchor": "definitions-variables-list",
 				"title": "List",
 				"type": "object",
 				"required": ["values"],
@@ -441,7 +413,6 @@
 				"unevaluatedProperties": false
 			},
 			"sql": {
-				"$anchor": "definitions-variables-sql",
 				"title": "SQL",
 				"type": "object",
 				"required": ["query", "driver", "url"],
@@ -464,7 +435,6 @@
 				"unevaluatedProperties": false
 			},
 			"javascript": {
-				"$anchor": "definitions-variables-javascript",
 				"title": "Javascript",
 				"type": "object",
 				"required": ["script"],
@@ -479,7 +449,6 @@
 				"unevaluatedProperties": false
 			},
 			"random_uuid": {
-				"$anchor": "definitions-variables-random_uuid",
 				"title": "Random UUID",
 				"type": "object",
 				"allOf": [
@@ -500,7 +469,6 @@
 				"unevaluatedProperties": false
 			},
 			"shared_queue": {
-				"$anchor": "definitions-variables-shared_queue",
 				"title": "Shared Queue",
 				"type": "object",
 				"allOf": [
@@ -541,7 +509,6 @@
 			}
 		},
 		"server": {
-			"$anchor": "definitions-server",
 			"title": "Server",
 			"type": "object",
 			"required": ["name", "host"],
@@ -550,7 +517,6 @@
 				"name": { "$ref": "#/definitions/common/text" },
 				"host": { "$ref": "#/definitions/common/text" },
 				"scheme": {
-					"$anchor": "root-servers-items-scheme",
 					"type": "string",
 					"enum": ["http", "https"]
 				},
@@ -564,7 +530,6 @@
 		},
 		"authentication": {
 			"auth-generic": {
-				"$anchor": "definitions-authentication-auth-generic",
 				"type": "object",
 				"required": ["login", "password"],
 				"properties": {
@@ -573,7 +538,6 @@
 				}
 			},
 			"auth-generic-domain": {
-				"$anchor": "definitions-authentication-auth-generic-domain",
 				"type": "object",
 				"allOf": [
 					{ "$ref": "#/definitions/authentication/auth-generic" },
@@ -585,7 +549,6 @@
 				]
 			},
 			"basic": {
-				"$anchor": "definitions-authentication-basic",
 				"title": "Basic Authentication",
 				"type": "object",
 				"allOf": [
@@ -598,20 +561,17 @@
 				]
 			},
 			"ntlm": {
-				"$anchor": "definitions-authentication-ntlm",
 				"title": "NTLM Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			},
 			"negotiate": {
-				"$anchor": "definitions-authentication-negotiate",
 				"title": "Negotiate Authentication",
 				"type": "object",
 				"allOf": [{ "$ref": "#/definitions/authentication/auth-generic-domain" }]
 			}
 		},
 		"sla": {
-			"$anchor": "definitions-sla",
 			"title": "SLA Profile",
 			"type": "object",
 			"required": ["name", "thresholds"],
@@ -619,7 +579,6 @@
 				"name": { "$ref": "#/definitions/common/text" },
 				"description": { "$ref": "#/definitions/common/text" },
 				"thresholds": {
-					"$anchor": "definitions-sla-thresholds",
 					"title": "Thresholds",
 					"type": "array",
 					"minItems": 1,
@@ -628,7 +587,6 @@
 				}
 			},
 			"threshold": {
-				"$anchor": "definitions-sla-threshold",
 				"title": "Threshold",
 				"type": "string",
 				"pattern": "^(.*?)\\s(warn\\s(>=|==|<=|>|<))(?=\\s)(.*?)per\\s(test|interval)$"
@@ -636,7 +594,6 @@
 		},
 		"populations": {
 			"population": {
-				"$anchor": "definitions-population",
 				"title": "Population",
 				"type": "object",
 				"properties": {
@@ -660,7 +617,6 @@
 				}
 			},
 			"constant_load": {
-				"$anchor": "definitions-populations-constant_load",
 				"title": "Constant Load",
 				"type": "object",
 				"required": ["users"],
@@ -676,7 +632,6 @@
 				}
 			},
 			"rampup_load": {
-				"$anchor": "definitions-populations-rampup_load",
 				"title": "Ramp-up Load",
 				"type": "object",
 				"required": ["min_users", "increment_users", "increment_every"],
@@ -696,7 +651,6 @@
 				"additionalProperties": false
 			},
 			"peaks_load": {
-				"$anchor": "definitions-populations-peaks_load",
 				"title": "Peaks Load",
 				"type": "object",
 				"required": ["minimum", "maximum", "start"],
@@ -715,7 +669,6 @@
 				"additionalProperties": false
 			},
 			"peaks_phase": {
-				"$anchor": "definitions-populations-peaks_phase",
 				"title": "Peak Phase",
 				"type": "object",
 				"required": ["users", "duration"],
@@ -725,7 +678,6 @@
 				}
 			},
 			"custom_load": {
-				"$anchor": "definitions-populations-custom_load",
 				"title": "Custom Load",
 				"type": "object",
 				"required": ["steps"],
@@ -742,7 +694,6 @@
 				"additionalProperties": false
 			},
 			"custom_policy_step": {
-				"$anchor": "definitions-populations-custom_policy_step",
 				"title": "Custom Policy Step",
 				"type": "object",
 				"required": ["when", "users"],
@@ -754,7 +705,6 @@
 			}
 		},
 		"scenario": {
-			"$anchor": "definitions-scenario",
 			"title": "Scenario",
 			"type": "object",
 			"properties": {
@@ -776,14 +726,12 @@
 					"items": { "$ref": "#/definitions/scenario/rendezvous_policy" }
 				},
 				"populations": {
-					"$anchor": "definitions-scenario-populations",
 					"title": "Scenario Populations",
 					"type": "array",
 					"minItems": 1,
 					"additionalItems": false,
 					"additionalProperties": false,
 					"items": {
-						"$anchor": "definitions-scenario-populations-items",
 						"type": "object",
 						"required": ["name"],
 						"properties": {
@@ -797,7 +745,6 @@
 				}
 			},
 			"apm": {
-				"$anchor": "definitions-scenario-apm",
 				"title": "APM Configuration",
 				"type": "object",
 				"properties": {
@@ -813,7 +760,6 @@
 				"additionalProperties": false
 			},
 			"dynatrace_anomaly_rule": {
-				"$anchor": "definitions-scenario-dynatrace_anomaly_rule",
 				"title": "Dynatrace Anomaly Rule",
 				"type": "object",
 				"required": ["metric_id", "operator", "value", "severity"],
@@ -832,7 +778,6 @@
 				"additionalProperties": false
 			},
 			"monitoring": {
-				"$anchor": "definitions-scenario-monitoring",
 				"title": "Monitoring Parameters",
 				"type": "object",
 				"properties": {
@@ -842,7 +787,6 @@
 				"additionalProperties": false
 			},
 			"rendezvous_policy": {
-				"$anchor": "definitions-scenario-rendezvous_policy",
 				"title": "Rendezvous Policy",
 				"type": "object",
 				"required": ["name"],
@@ -856,7 +800,6 @@
 		},
 		"user_paths": {
 			"user_path": {
-				"$anchor": "definitions-user_paths-user_path",
 				"title": "User Path",
 				"type": "object",
 				"required": ["name", "actions"],
@@ -873,7 +816,6 @@
 				}
 			},
 			"container": {
-				"$anchor": "definitions-user_paths-container",
 				"title": "Containers",
 				"type": "object",
 				"required": ["steps"],
@@ -894,7 +836,6 @@
 				}
 			},
 			"steps": {
-				"$anchor": "definitions-user_paths-steps",
 				"title": "Steps",
 				"type": "array",
 				"minItems": 1,
@@ -926,7 +867,6 @@
 			},
 			"actions": {
 				"transaction": {
-					"$anchor": "definitions-user_paths-actions-transaction",
 					"name": "transaction",
 					"title": "Action: Transaction",
 					"type": "object",
@@ -949,7 +889,6 @@
 					"additionalProperties": false
 				},
 				"http_page": {
-					"$anchor": "definitions-user_paths-actions-http_page",
 					"name": "http_page",
 					"title": "Action: HTTP Page",
 					"type": "object",
@@ -979,7 +918,6 @@
 					"additionalProperties": false
 				},
 				"request": {
-					"$anchor": "definitions-user_paths-actions-request",
 					"title": "Action: HTTP/s Request",
 					"type": "object",
 					"required": ["url"],
@@ -1031,19 +969,16 @@
 					}
 				},
 				"delay": {
-					"$anchor": "definitions-user_paths-actions-delay",
 					"title": "Action: Delay",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"think_time": {
-					"$anchor": "definitions-user_paths-actions-think_time",
 					"title": "Action: Think Time",
 					"type": "string",
 					"allOf": [{ "$ref": "#/definitions/common/text" }]
 				},
 				"javascript": {
-					"$anchor": "definitions-user_paths-actions-javascript",
 					"title": "Action: Javascript",
 					"type": "object",
 					"required": ["name", "script"],
@@ -1054,7 +989,6 @@
 					}
 				},
 				"if": {
-					"$anchor": "definitions-user_paths-actions-if",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["then"],
@@ -1073,7 +1007,6 @@
 					"additionalProperties": false
 				},
 				"while": {
-					"$anchor": "definitions-user_paths-actions-while",
 					"title": "Action: While",
 					"type": "object",
 					"required": ["steps"],
@@ -1091,7 +1024,6 @@
 					"additionalProperties": false
 				},
 				"loop": {
-					"$anchor": "definitions-user_paths-actions-loop",
 					"title": "Action: If",
 					"type": "object",
 					"required": ["count", "steps"],
@@ -1104,7 +1036,6 @@
 					"additionalProperties": false
 				},
 				"switch": {
-					"$anchor": "definitions-user_paths-actions-switch",
 					"title": "Action: Switch",
 					"type": "object",
 					"required": ["value", "default"],
@@ -1121,7 +1052,6 @@
 					"additionalProperties": false
 				},
 				"custom_action": {
-					"$anchor": "definitions-user_paths-actions-custom_action",
 					"title": "Action: Custom Action",
 					"type": "object",
 					"required": ["name", "type"],
@@ -1142,13 +1072,11 @@
 					"additionalProperties": false
 				},
 				"go_to_next_iteration": {
-					"$anchor": "definitions-user_paths-actions-go_to_next_iteration",
 					"title": "Action: Go to next iteration",
 					"type": "object",
 					"additionalProperties": false
 				},
 				"stop_vu": {
-					"$anchor": "definitions-user_paths-actions-stop_vu",
 					"title": "Action: Stop Virtual User",
 					"type": "object",
 					"properties": {
@@ -1160,7 +1088,6 @@
 					"additionalProperties": false
 				},
 				"fork": {
-					"$anchor": "definitions-user_paths-actions-fork",
 					"title": "Action: Fork",
 					"type": "object",
 					"required": ["steps"],
@@ -1176,7 +1103,6 @@
 					"additionalProperties": false
 				},
 				"wait_until": {
-					"$anchor": "definitions-user_paths-actions-wait_until",
 					"title": "Action: Wait Until",
 					"type": "object",
 					"required": ["conditions"],
@@ -1194,7 +1120,6 @@
 					"additionalProperties": false
 				},
 				"variable_modifier": {
-					"$anchor": "definitions-user_paths-actions-variable_modifier",
 					"title": "Action: Variable Modifier",
 					"type": "object",
 					"required": ["mode"],
@@ -1218,7 +1143,6 @@
 					"additionalProperties": false
 				},
 				"debug_logger": {
-					"$anchor": "definitions-user_paths-actions-debug_logger",
 					"title": "Action: Debug Logger",
 					"type": "object",
 					"required": ["text"],
@@ -1229,7 +1153,6 @@
 					"additionalProperties": false
 				},
 				"rendezvous": {
-					"$anchor": "definitions-user_paths-actions-rendezvous",
 					"title": "Action: Rendezvous",
 					"type": "object",
 					"required": ["name"],
@@ -1240,7 +1163,6 @@
 					"additionalProperties": false
 				},
 				"try_catch": {
-					"$anchor": "definitions-user_paths-actions-try_catch",
 					"title": "Action: Try Catch",
 					"type": "object",
 					"required": ["try"],
@@ -1295,7 +1217,6 @@
 				}
 			},
 			"content_assertion": {
-				"$anchor": "definitions-user_paths-content_assertion",
 				"title": "Content Assertion",
 				"type": "object",
 				"properties": {
@@ -1315,7 +1236,6 @@
 				"additionalProperties": false
 			},
 			"part": {
-				"$anchor": "definitions-user_paths-part",
 				"title": "Multipart Part",
 				"type": "object",
 				"required": ["name"],
@@ -1331,7 +1251,6 @@
 				"additionalProperties": false
 			},
 			"size_assertion": {
-				"$anchor": "definitions-user_paths-size_assertion",
 				"title": "Size Assertion",
 				"type": "object",
 				"required": ["operator", "value"],
@@ -1349,7 +1268,6 @@
 				"additionalProperties": false
 			},
 			"duration_assertion": {
-				"$anchor": "definitions-user_paths-duration_assertion",
 				"title": "Duration Assertion",
 				"type": "object",
 				"required": ["value"],
@@ -1363,7 +1281,6 @@
 				"additionalProperties": false
 			},
 			"assertion_wrapper": {
-				"$anchor": "definitions-user_paths-assertion_wrapper",
 				"title": "Assertion (wrapped)",
 				"type": "object",
 				"properties": {
@@ -1401,7 +1318,6 @@
 		},
 		"framework": {
 			"builtin_framework_ref": {
-				"$anchor": "definitions-framework-builtin_framework_ref",
 				"title": "Built-in Framework Reference",
 				"type": "object",
 				"required": ["name"],
@@ -1416,7 +1332,6 @@
 				"additionalProperties": false
 			},
 			"custom_framework": {
-				"$anchor": "definitions-framework-custom_framework",
 				"title": "Custom Framework",
 				"type": "object",
 				"required": ["name", "parameters"],
@@ -1436,7 +1351,6 @@
 				"additionalProperties": false
 			},
 			"dynamic_parameter": {
-				"$anchor": "definitions-framework-dynamic_parameter",
 				"title": "Dynamic Parameter",
 				"type": "object",
 				"required": ["name"],


### PR DESCRIPTION
## Summary

Make the as-code JSON schema actually enforce what it claims to, and align it with how real projects are written. Targets `schemas/v3.1/as-code.schema.json` (the versioned schema introduced on this branch) rather than the legacy `neoload-project/src/main/resources/as-code.latest.schema.json`.

## Changes

- Replace the non-standard, silently-neutralised `xrequired` / `x-d7nosupport-additionalProperties` keywords with the real JSON-Schema keywords `required` / `unevaluatedProperties: false`, so missing required fields and unknown/misspelled properties are actually caught. Covers all 13 variable types on this branch (including `random_string`, `password`, `date`, `current_date`, `list`, `sql`, `random_uuid`, `shared_queue` added since `v3`). Bump `$schema` to Draft 2019-09 (needed for `unevaluatedProperties`).
- Fix the `descrption` typo (→ `description`) in the generic variable definition.
- Remove every decorative, non-root `$id` (86 sites, e.g. `"$id": "#root/includes"`). Draft 2019-09 treats a bare-fragment `$id` as a base-URI change for its subtree, breaking `#/definitions/...` pointer refs nested underneath (`PointerToNowhere`) - Draft-07 tolerated the same values as harmless plain-name anchors. No `$ref` in this schema ever targets any of these identifiers, so they're dropped outright rather than kept around in another form.
- Fix `properties.variables.items`: it expected a flat object matching one of the 13 variable-type schemas directly, but every real as-code project writes it wrapped under the type name (e.g. `variables: [{ constant: { name: ..., value: ... } }]`). Changed to an object with exactly one of the 13 type keys (`minProperties`/`maxProperties: 1`, `additionalProperties: false`), each still validated against the existing flat variable-type definitions.
- **Close remaining strictness gaps that had no guard at all** (found by deliberately introducing a typo in a population and confirming validate missed it): added `additionalProperties: false` to `sla`, `population` (+ its `user_paths` items), `constant_load`, `peaks_phase`, `scenario` (top-level), `scenario.populations.items`, `user_path`, `container`, `actions.request`, `actions.javascript`, `extractor`; added `required: ["name"]` to `population` and `scenario`, which had no required field at all; added `unevaluatedProperties: false` to the authentication chain (`auth-generic-domain`, `basic`, `ntlm`, `negotiate`); added `minProperties`/`maxProperties: 1` to `frameworks.items`, `user_paths.steps.items` and `assertion_wrapper` (same "exactly one named key" wrapper shape as `variables.items`, missing the cardinality constraint).
- Fixed a pre-existing bug found along the way: `negotiate_authentication` referenced `#/definitions/authentication/basic` (login/password/realm only) instead of `.../negotiate` (which extends `auth-generic-domain` with `domain`) - real projects using `negotiate_authentication` with a `domain` field would have been wrongly rejected by the strict validation without this fix.
- Fixed a regression from the `container` `additionalProperties: false` above: `description` was omitted even though it's legitimately used on `if.then`/`else`, `init`/`actions`/`end`, `try_catch.try`/`catch`.

## Verified

- Schema stays valid JSON.
- Validated with the real `jsonschema` library (Draft 2019-09) against: the real multi-file `as-code-full-syntax` project (merged with its includes) - **0 errors**; a project with a missing required field, an unknown property, and a missing required server field - correctly **rejected** with exactly those 3 errors; a deliberately-introduced typo (`namessss` instead of `name`) in a population - correctly caught; and the **full set of ~54 `neoload-project` Java round-trip test fixtures** (representative of real supported syntax) to catch any other schema/reality mismatch.

## Known follow-up (out of scope for this PR)

The full-fixture sweep above surfaced several additional, pre-existing gaps not touched here: missing `distribution`/`order`/`name`/`assertions` properties in a few places, `delay`/`think_time`/variable `value` accepting only `string` instead of also `number`, the `iterations` pattern rejecting the singular form (`"1 iteration"`), the `sla` threshold pattern requiring an optional `per test|interval` suffix, the `secret_vault` variable type missing entirely from this schema (present in the legacy `as-code.latest.schema.json`), and `go_to_next_iteration` supporting a bare-string shorthand not just an object form. Tracked separately.