### PR TITLE
Use antlr4-runtime instead of antlr4 tool jar

### DIFF
--- a/models-readers/loadrunner-reader/pom.xml
+++ b/models-readers/loadrunner-reader/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
+            <artifactId>antlr4-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.immutables</groupId>

--- a/neoload-project/pom.xml
+++ b/neoload-project/pom.xml
@@ -38,7 +38,7 @@
 	    </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
-            <artifactId>antlr4</artifactId>
+            <artifactId>antlr4-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.immutables</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>
-				<artifactId>antlr4</artifactId>
+				<artifactId>antlr4-runtime</artifactId>
 				<version>${antlr.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
## Summary
- Replace the runtime `org.antlr:antlr4` dependency with `antlr4-runtime` in `neoload-project` and `loadrunner-reader`.
- Update parent `dependencyManagement` accordingly so the full ANTLR tool (and transitive `icu4j`) is only used by the Maven plugin at build time.

## Test plan
- [x] `mvn -pl neoload-project,models-readers/loadrunner-reader -am compile`
- [x] Confirm `icu4j` is no longer a transitive runtime dependency of these modules

Made with [Cursor](https://cursor.com)