### PR TITLE
LOAD-38852: shared_queue variable YAML DSL — nested swap_file, writer, docs

### DIFF
--- a/neoload-project/doc/v3/variables.md
+++ b/neoload-project/doc/v3/variables.md
@@ -208,3 +208,34 @@ secret_vault:
   provider_id: 665f1a2b3c4d5e6f7a8b9c0d
   secret_identifier: my-app/db
 ```
+
+## Shared Queue variable
+A queue shared between virtual users, usable as a producer/consumer channel, with optional persistence to a file.
+
+| Name                    | Description                                                                 | Accept variable | Required | Since |
+|:----------------------- |:--------------------------------------------------------------------------- |:---------------:|:--------:|:-----:|
+| name                    | The variable name                                                           | -               | &#x2713; |       |
+| description             | The variable description                                                    | -               | -        |       |
+| queue_size              | The maximum number of elements the queue can hold.</br>The default value is `10000`. | -    | -        |       |
+| consumer_timeout        | The time, in milliseconds, a consumer waits for a value before giving up.</br>The default value is `5000`. | - | -   |       |
+| swap_file               | The file used to persist the queue content. See below. When absent, no file swap is used. | -   | -        |       |
+| swap_file.path          | The relative (compared to the NeoLoad project folder) or absolute path of the swap file. | -    | &#x2713; |       |
+| swap_file.delimiter     | The delimiter used to separate data columns in the swap file.</br>The default value is `;`. | -    | -        |       |
+| swap_file.load_from_file| If `true`, the queue is populated from the swap file at test start.</br>The default value is `false`. | -    | -        |       |
+| swap_file.save_to_file  | If `true`, the queue content is written to the swap file at test end.</br>The default value is `true`. | -    | -        |       |
+
+#### Example
+Defining a Shared Queue variable.
+
+```yaml
+shared_queue:
+  name: MySharedQueue
+  description: MySharedQueueDescription
+  queue_size: 5000
+  consumer_timeout: 2000
+  swap_file:
+    path: data/my_queue.csv
+    delimiter: ","
+    load_from_file: true
+    save_to_file: false
+```

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueSwapFile.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueSwapFile.java
@@ -1,0 +1,55 @@
+package com.neotys.neoload.model.v3.project.variable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.neotys.neoload.model.v3.validation.constraints.RequiredCheck;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import javax.validation.constraints.Size;
+import org.immutables.value.Value;
+
+@JsonInclude(value = Include.NON_EMPTY)
+@JsonPropertyOrder({SharedQueueSwapFile.PATH, SharedQueueSwapFile.DELIMITER, SharedQueueSwapFile.LOAD_FROM_FILE, SharedQueueSwapFile.SAVE_TO_FILE})
+@JsonSerialize(as = ImmutableSharedQueueSwapFile.class)
+@JsonDeserialize(as = ImmutableSharedQueueSwapFile.class)
+@Value.Immutable
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+public interface SharedQueueSwapFile {
+	String PATH           = "path";
+	String DELIMITER      = "delimiter";
+	String LOAD_FROM_FILE = "load_from_file";
+	String SAVE_TO_FILE   = "save_to_file";
+
+	@RequiredCheck(groups = {NeoLoad.class})
+	@JsonProperty(PATH)
+	String getPath();
+
+	@JsonProperty(DELIMITER)
+	@Value.Default
+	@Size(min = 1, max = 1, groups = {NeoLoad.class})
+	default String getDelimiter() {
+		return ";";
+	}
+
+	@JsonProperty(LOAD_FROM_FILE)
+	@Value.Default
+	default boolean isLoadFromFile() {
+		return false;
+	}
+
+	@JsonProperty(SAVE_TO_FILE)
+	@Value.Default
+	default boolean isSaveToFile() {
+		return true;
+	}
+
+	class Builder extends ImmutableSharedQueueSwapFile.Builder {
+	}
+
+	static Builder builder() {
+		return new Builder();
+	}
+}

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueVariable.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueVariable.java
@@ -1,34 +1,26 @@
 package com.neotys.neoload.model.v3.project.variable;
 
-import java.util.Optional;
-
-import javax.validation.constraints.Size;
-
-import org.immutables.value.Value;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.neotys.neoload.model.v3.validation.constraints.RangeCheck;
 import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import java.util.Optional;
+import javax.validation.Valid;
+import org.immutables.value.Value;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @JsonDeserialize(as = ImmutableSharedQueueVariable.class)
 @JsonPropertyOrder({Variable.NAME, Variable.DESCRIPTION, SharedQueueVariable.QUEUE_SIZE, SharedQueueVariable.CONSUMER_TIMEOUT,
-		SharedQueueVariable.SWAP_ACTIVATED, SharedQueueVariable.SWAP_FILE, SharedQueueVariable.SWAP_LOADED,
-		SharedQueueVariable.SWAP_DUMP, SharedQueueVariable.DELIMITER})
+		SharedQueueVariable.SWAP_FILE})
 @Value.Immutable
 @Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
 public interface SharedQueueVariable extends Variable {
 
-	String QUEUE_SIZE        = "queue_size";
-	String CONSUMER_TIMEOUT  = "consumer_timeout";
-	String SWAP_ACTIVATED    = "swap_activated";
-	String SWAP_FILE         = "swap_file";
-	String SWAP_LOADED       = "swap_loaded";
-	String SWAP_DUMP         = "swap_dump";
-	String DELIMITER         = "delimiter";
+	String QUEUE_SIZE       = "queue_size";
+	String CONSUMER_TIMEOUT = "consumer_timeout";
+	String SWAP_FILE        = "swap_file";
 
 	@JsonProperty(QUEUE_SIZE)
 	@Value.Default
@@ -44,33 +36,9 @@ public interface SharedQueueVariable extends Variable {
 		return 5000;
 	}
 
-	@JsonProperty(SWAP_ACTIVATED)
-	@Value.Default
-	default boolean isSwapActivated() {
-		return false;
-	}
-
+	@Valid
 	@JsonProperty(SWAP_FILE)
-	Optional<String> getSwapFile();
-
-	@JsonProperty(SWAP_LOADED)
-	@Value.Default
-	default boolean isSwapLoaded() {
-		return false;
-	}
-
-	@JsonProperty(SWAP_DUMP)
-	@Value.Default
-	default boolean isSwapDump() {
-		return true;
-	}
-
-	@JsonProperty(DELIMITER)
-	@Value.Default
-	@Size(min = 1, max = 1, groups = {NeoLoad.class})
-	default String getDelimiter() {
-		return ";";
-	}
+	Optional<SharedQueueSwapFile> getSwapFile();
 
 	class Builder extends ImmutableSharedQueueVariable.Builder {}
 

--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -228,6 +228,15 @@
 					"change_policy": { "$ref": "#/definitions/common/var_change_policy" }
 				}
 			},
+			"generic_no_policy": {
+				"$id": "#/definitions/variables/generic_no_policy",
+				"type": "object",
+				"xrequired": ["name"],
+				"properties": {
+					"name": { "$ref": "#/definitions/common/name" },
+					"description": { "$ref": "#/definitions/common/text" }
+				}
+			},
 			"constant": {
 				"$id": "#/definitions/variables/constant",
 				"title": "Constant",
@@ -501,7 +510,7 @@
 				"title": "Shared Queue",
 				"type": "object",
 				"allOf": [
-					{ "$ref": "#/definitions/variables/generic" },
+					{ "$ref": "#/definitions/variables/generic_no_policy" },
 					{
 						"properties": {
 							"queue_size": {
@@ -514,22 +523,24 @@
 								"minimum": 0,
 								"default": 5000
 							},
-							"swap_activated": {
-								"type": "boolean",
-								"default": false
-							},
-							"swap_file": { "$ref": "#/definitions/common/text" },
-							"swap_loaded": {
-								"type": "boolean",
-								"default": false
-							},
-							"swap_dump": {
-								"type": "boolean",
-								"default": true
-							},
-							"delimiter": {
-								"$ref": "#/definitions/common/text",
-								"default": ";"
+							"swap_file": {
+								"type": "object",
+								"required": ["path"],
+								"properties": {
+									"path": { "$ref": "#/definitions/common/text" },
+									"delimiter": {
+										"$ref": "#/definitions/common/text",
+										"default": ";"
+									},
+									"load_from_file": {
+										"type": "boolean",
+										"default": false
+									},
+									"save_to_file": {
+										"type": "boolean",
+										"default": true
+									}
+								}
 							}
 						}
 					}

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOVariableTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOVariableTest.java
@@ -1,12 +1,6 @@
 package com.neotys.neoload.model.v3.binding.io;
 
 
-import com.neotys.neoload.model.v3.project.Project;
-import com.neotys.neoload.model.v3.project.variable.*;
-import org.junit.Test;
-
-import java.io.IOException;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static com.neotys.neoload.model.v3.project.variable.Variable.ChangePolicy.*;
 import static com.neotys.neoload.model.v3.project.variable.Variable.Order.*;
@@ -14,6 +8,10 @@ import static com.neotys.neoload.model.v3.project.variable.Variable.OutOfValue.*
 import static com.neotys.neoload.model.v3.project.variable.Variable.Scope.*;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.neotys.neoload.model.v3.project.Project;
+import com.neotys.neoload.model.v3.project.variable.*;
+import java.io.IOException;
+import org.junit.Test;
 
 public class IOVariableTest extends AbstractIOElementsTest {
 
@@ -166,12 +164,12 @@ public class IOVariableTest extends AbstractIOElementsTest {
                 .description("A producer/consumer shared queue")
                 .queueSize(5000)
                 .consumerTimeout(2000L)
-                .isSwapActivated(true)
-                .swapFile("data/my_queue_swap.csv")
-                .isSwapLoaded(true)
-                .isSwapDump(false)
-                .delimiter(",")
-                .changePolicy(EACH_REQUEST)
+                .swapFile(SharedQueueSwapFile.builder()
+                        .path("data/my_queue_swap.csv")
+                        .delimiter(",")
+                        .isLoadFromFile(true)
+                        .isSaveToFile(false)
+                        .build())
                 .build();
 
         final Variable secretVaultVariable = SecretVaultVariable.builder()

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/validation/validator/SharedQueueVariableTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/validation/validator/SharedQueueVariableTest.java
@@ -1,0 +1,70 @@
+package com.neotys.neoload.model.v3.validation.validator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.neotys.neoload.model.v3.project.variable.SharedQueueSwapFile;
+import com.neotys.neoload.model.v3.project.variable.SharedQueueVariable;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import org.junit.Test;
+
+public class SharedQueueVariableTest {
+
+	@Test
+	public void validateSwapFileWithoutPath() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("swap_file.path"));
+	}
+
+	@Test
+	public void validateSwapFileDelimiterSize() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("data/my_queue.csv").delimiter("ab").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("swap_file.delimiter"));
+	}
+
+	@Test
+	public void validateQueueSizeMinimum() {
+		final Validator validator = new Validator();
+
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.queueSize(0)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("queue_size"));
+	}
+
+	@Test
+	public void validateFullyValidSharedQueue() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("data/my_queue.csv").delimiter(",").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertTrue(validation.isValid());
+	}
+}

--- a/neoload-project/src/test/resources/test-variable-only-required.json
+++ b/neoload-project/src/test/resources/test-variable-only-required.json
@@ -160,12 +160,12 @@
         "description": "A producer/consumer shared queue",
         "queue_size": 5000,
         "consumer_timeout": 2000,
-        "swap_activated": true,
-        "swap_file": "data/my_queue_swap.csv",
-        "swap_loaded": true,
-        "swap_dump": false,
-        "delimiter": ",",
-        "change_policy": "each_request"
+        "swap_file": {
+          "path": "data/my_queue_swap.csv",
+          "delimiter": ",",
+          "load_from_file": true,
+          "save_to_file": false
+        }
       }
     },
     {

--- a/neoload-project/src/test/resources/test-variable-only-required.yaml
+++ b/neoload-project/src/test/resources/test-variable-only-required.yaml
@@ -105,12 +105,11 @@ variables:
     description: A producer/consumer shared queue
     queue_size: 5000
     consumer_timeout: 2000
-    swap_activated: true
-    swap_file: data/my_queue_swap.csv
-    swap_loaded: true
-    swap_dump: false
-    delimiter: ","
-    change_policy: each_request
+    swap_file:
+      path: data/my_queue_swap.csv
+      delimiter: ","
+      load_from_file: true
+      save_to_file: false
 - secret_vault:
     name: db_password
     provider_id: 665f1a2b3c4d5e6f7a8b9c0d


### PR DESCRIPTION
## Summary

- Restructures the `shared_queue` as-code variable so all swap-related settings live in a nested `swap_file` object, with swap activation derived from its presence instead of a redundant flag.
- Adds the NeoLoad XML writer for `shared_queue`, a `generic_no_policy` schema definition (no change policy / scope / order / out-of-value, which the legacy runtime ignores for this type), and the `variables.md` section.
- Plan: `.claude/handoffs/LOAD-38852.md` in the workspace repo.

## Test plan

- `mvn test` in `neoload-project` and `neoload-writer`.
- Round-trip (read/write/read) coverage for required-only and full-optional YAML, validator coverage for missing `swap_file.path`, non-single-character `delimiter`, and `queue_size` below minimum, plus an XML writer attribute assertion.