### PR TITLE
LOAD-38852: add shared_queue variable type with nested swap_file config

### DIFF
--- a/neoload-project/doc/v3/variables.md
+++ b/neoload-project/doc/v3/variables.md
@@ -175,3 +175,34 @@ Defining a JavaScript variable.
       myLibraryFunction();\n\t};\n}"
     change_policy: each_iteration
 ```
+
+## Shared Queue variable
+A queue shared between virtual users, usable as a producer/consumer channel, with optional persistence to a file.
+
+| Name                    | Description                                                                 | Accept variable | Required | Since |
+|:----------------------- |:--------------------------------------------------------------------------- |:---------------:|:--------:|:-----:|
+| name                    | The variable name                                                           | -               | &#x2713; | 2026.3|
+| description             | The variable description                                                    | -               | -        | 2026.3|
+| queue_size              | The maximum number of elements the queue can hold.</br>The default value is `10000`. | -    | -        | 2026.3|
+| consumer_timeout        | The time, in milliseconds, a consumer waits for a value before giving up.</br>The default value is `5000`. | - | -   | 2026.3|
+| swap_file               | The file used to persist the queue content. See below. When absent, no file swap is used. | -   | -        | 2026.3|
+| swap_file.path          | The relative (compared to the NeoLoad project folder) or absolute path of the swap file. | -    | &#x2713; | 2026.3|
+| swap_file.delimiter     | The delimiter used to separate data columns in the swap file.</br>The default value is `;`. | -    | -        | 2026.3|
+| swap_file.load_from_file| If `true`, the queue is populated from the swap file at test start.</br>The default value is `false`. | -    | -        | 2026.3|
+| swap_file.save_to_file  | If `true`, the queue content is written to the swap file at test end.</br>The default value is `true`. | -    | -        | 2026.3|
+
+#### Example
+Defining a Shared Queue variable.
+
+```yaml
+shared_queue:
+  name: MySharedQueue
+  description: MySharedQueueDescription
+  queue_size: 5000
+  consumer_timeout: 2000
+  swap_file:
+    path: data/my_queue.csv
+    delimiter: ","
+    load_from_file: true
+    save_to_file: false
+```

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueSwapFile.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueSwapFile.java
@@ -1,0 +1,55 @@
+package com.neotys.neoload.model.v3.project.variable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.neotys.neoload.model.v3.validation.constraints.RequiredCheck;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import javax.validation.constraints.Size;
+import org.immutables.value.Value;
+
+@JsonInclude(value = Include.NON_EMPTY)
+@JsonPropertyOrder({SharedQueueSwapFile.PATH, SharedQueueSwapFile.DELIMITER, SharedQueueSwapFile.LOAD_FROM_FILE, SharedQueueSwapFile.SAVE_TO_FILE})
+@JsonSerialize(as = ImmutableSharedQueueSwapFile.class)
+@JsonDeserialize(as = ImmutableSharedQueueSwapFile.class)
+@Value.Immutable
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+public interface SharedQueueSwapFile {
+	String PATH           = "path";
+	String DELIMITER      = "delimiter";
+	String LOAD_FROM_FILE = "load_from_file";
+	String SAVE_TO_FILE   = "save_to_file";
+
+	@RequiredCheck(groups = {NeoLoad.class})
+	@JsonProperty(PATH)
+	String getPath();
+
+	@JsonProperty(DELIMITER)
+	@Value.Default
+	@Size(min = 1, max = 1, groups = {NeoLoad.class})
+	default String getDelimiter() {
+		return ";";
+	}
+
+	@JsonProperty(LOAD_FROM_FILE)
+	@Value.Default
+	default boolean isLoadFromFile() {
+		return false;
+	}
+
+	@JsonProperty(SAVE_TO_FILE)
+	@Value.Default
+	default boolean isSaveToFile() {
+		return true;
+	}
+
+	class Builder extends ImmutableSharedQueueSwapFile.Builder {
+	}
+
+	static Builder builder() {
+		return new Builder();
+	}
+}

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueVariable.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/SharedQueueVariable.java
@@ -1,0 +1,48 @@
+package com.neotys.neoload.model.v3.project.variable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.neotys.neoload.model.v3.validation.constraints.RangeCheck;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import java.util.Optional;
+import javax.validation.Valid;
+import org.immutables.value.Value;
+
+@JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(as = ImmutableSharedQueueVariable.class)
+@JsonPropertyOrder({Variable.NAME, Variable.DESCRIPTION, SharedQueueVariable.QUEUE_SIZE, SharedQueueVariable.CONSUMER_TIMEOUT,
+		SharedQueueVariable.SWAP_FILE})
+@Value.Immutable
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+public interface SharedQueueVariable extends Variable {
+
+	String QUEUE_SIZE       = "queue_size";
+	String CONSUMER_TIMEOUT = "consumer_timeout";
+	String SWAP_FILE        = "swap_file";
+
+	@JsonProperty(QUEUE_SIZE)
+	@Value.Default
+	@RangeCheck(min = 1, groups = {NeoLoad.class})
+	default int getQueueSize() {
+		return 10000;
+	}
+
+	@JsonProperty(CONSUMER_TIMEOUT)
+	@Value.Default
+	@RangeCheck(min = 0, groups = {NeoLoad.class})
+	default long getConsumerTimeout() {
+		return 5000;
+	}
+
+	@Valid
+	@JsonProperty(SWAP_FILE)
+	Optional<SharedQueueSwapFile> getSwapFile();
+
+	class Builder extends ImmutableSharedQueueVariable.Builder {}
+
+	static Builder builder() {
+		return new Builder();
+	}
+}

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/Variable.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/variable/Variable.java
@@ -16,8 +16,8 @@ import org.immutables.value.Value;
 		@JsonSubTypes.Type(value = ImmutableFileVariable.class, name = "file"),
 		@JsonSubTypes.Type(value = ImmutableCounterVariable.class, name = "counter"),
 		@JsonSubTypes.Type(value = ImmutableRandomNumberVariable.class, name = "random_number"),
-		@JsonSubTypes.Type(value = ImmutableJavaScriptVariable.class, name = "javascript")
-
+		@JsonSubTypes.Type(value = ImmutableJavaScriptVariable.class, name = "javascript"),
+		@JsonSubTypes.Type(value = ImmutableSharedQueueVariable.class, name = "shared_queue")
 })
 // S2097 suppressed: the nested Jackson value-filter classes override equals(Object) to compare the
 // property value (not another filter instance), which is how the CUSTOM value filter selects the default

--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -41,7 +41,8 @@
 					{ "$ref": "#/definitions/variables/file" },
 					{ "$ref": "#/definitions/variables/counter" },
 					{ "$ref": "#/definitions/variables/random_number" },
-					{ "$ref": "#/definitions/variables/javascript" }
+					{ "$ref": "#/definitions/variables/javascript" },
+					{ "$ref": "#/definitions/variables/shared_queue" }
 				]
 			}
 		},
@@ -200,6 +201,15 @@
 					"change_policy": { "$ref": "#/definitions/common/var_change_policy" }
 				}
 			},
+			"generic_no_policy": {
+				"$id": "#/definitions/variables/generic_no_policy",
+				"type": "object",
+				"xrequired": ["name"],
+				"properties": {
+					"name": { "$ref": "#/definitions/common/name" },
+					"description": { "$ref": "#/definitions/common/text" }
+				}
+			},
 			"constant": {
 				"$id": "#/definitions/variables/constant",
 				"title": "Constant",
@@ -307,6 +317,48 @@
 					{
 						"properties": {
 							"script": { "$ref": "#/definitions/common/text" }
+						}
+					}
+				],
+				"x-d7nosupport-additionalProperties": false
+			},
+			"shared_queue": {
+				"$id": "#/definitions/variables/shared_queue",
+				"title": "Shared Queue",
+				"type": "object",
+				"allOf": [
+					{ "$ref": "#/definitions/variables/generic_no_policy" },
+					{
+						"properties": {
+							"queue_size": {
+								"type": "integer",
+								"minimum": 1,
+								"default": 10000
+							},
+							"consumer_timeout": {
+								"type": "integer",
+								"minimum": 0,
+								"default": 5000
+							},
+							"swap_file": {
+								"type": "object",
+								"required": ["path"],
+								"properties": {
+									"path": { "$ref": "#/definitions/common/text" },
+									"delimiter": {
+										"$ref": "#/definitions/common/text",
+										"default": ";"
+									},
+									"load_from_file": {
+										"type": "boolean",
+										"default": false
+									},
+									"save_to_file": {
+										"type": "boolean",
+										"default": true
+									}
+								}
+							}
 						}
 					}
 				],

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IORoundTripTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IORoundTripTest.java
@@ -83,7 +83,9 @@ public class IORoundTripTest extends AbstractIOElementsTest {
 			"test-variable-modifier-only-required",
 			"test-variable-modifier-required-and-optional",
 			"test-rendezvous-only-required",
-			"test-rendezvous-required-and-optional"
+			"test-rendezvous-required-and-optional",
+			"test-shared-queue-only-required",
+			"test-shared-queue-required-and-optional"
 	};
 
 	@Test

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOSharedQueueTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOSharedQueueTest.java
@@ -1,0 +1,76 @@
+package com.neotys.neoload.model.v3.binding.io;
+
+
+import static junit.framework.TestCase.assertNotNull;
+
+import com.neotys.neoload.model.v3.project.Project;
+import com.neotys.neoload.model.v3.project.variable.SharedQueueSwapFile;
+import com.neotys.neoload.model.v3.project.variable.SharedQueueVariable;
+import java.io.IOException;
+import org.junit.Test;
+
+public class IOSharedQueueTest extends AbstractIOElementsTest {
+
+	@Test
+	public void readSharedQueueOnlyRequired() throws IOException {
+		final Project expectedProject = buildProjectContainingSharedQueueOnlyRequired();
+		assertNotNull(expectedProject);
+
+		read("test-shared-queue-only-required", expectedProject);
+	}
+
+	@Test
+	public void writeSharedQueueOnlyRequired() throws IOException {
+		final Project expectedProject = buildProjectContainingSharedQueueOnlyRequired();
+		assertNotNull(expectedProject);
+
+		write("test-shared-queue-only-required", expectedProject);
+	}
+
+	@Test
+	public void readSharedQueueRequiredAndOptional() throws IOException {
+		final Project expectedProject = buildProjectContainingSharedQueueRequiredAndOptional();
+		assertNotNull(expectedProject);
+
+		read("test-shared-queue-required-and-optional", expectedProject);
+	}
+
+	@Test
+	public void writeSharedQueueRequiredAndOptional() throws IOException {
+		final Project expectedProject = buildProjectContainingSharedQueueRequiredAndOptional();
+		assertNotNull(expectedProject);
+
+		write("test-shared-queue-required-and-optional", expectedProject);
+	}
+
+	private Project buildProjectContainingSharedQueueOnlyRequired() {
+		final SharedQueueVariable minimalSharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.build();
+
+		return Project.builder()
+				.name("MyProject")
+				.addVariables(minimalSharedQueueVariable)
+				.build();
+	}
+
+	private Project buildProjectContainingSharedQueueRequiredAndOptional() {
+		final SharedQueueVariable fullSharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.description("A producer/consumer shared queue")
+				.queueSize(5000)
+				.consumerTimeout(2000L)
+				.swapFile(SharedQueueSwapFile.builder()
+						.path("data/my_queue_swap.csv")
+						.delimiter(",")
+						.isLoadFromFile(true)
+						.isSaveToFile(false)
+						.build())
+				.build();
+
+		return Project.builder()
+				.name("MyProject")
+				.addVariables(fullSharedQueueVariable)
+				.build();
+	}
+}

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOVariableTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IOVariableTest.java
@@ -1,12 +1,6 @@
 package com.neotys.neoload.model.v3.binding.io;
 
 
-import com.neotys.neoload.model.v3.project.Project;
-import com.neotys.neoload.model.v3.project.variable.*;
-import org.junit.Test;
-
-import java.io.IOException;
-
 import static com.google.common.collect.Lists.newArrayList;
 import static com.neotys.neoload.model.v3.project.variable.Variable.ChangePolicy.*;
 import static com.neotys.neoload.model.v3.project.variable.Variable.Order.*;
@@ -14,6 +8,10 @@ import static com.neotys.neoload.model.v3.project.variable.Variable.OutOfValue.*
 import static com.neotys.neoload.model.v3.project.variable.Variable.Scope.*;
 import static junit.framework.TestCase.assertNotNull;
 
+import com.neotys.neoload.model.v3.project.Project;
+import com.neotys.neoload.model.v3.project.variable.*;
+import java.io.IOException;
+import org.junit.Test;
 
 public class IOVariableTest extends AbstractIOElementsTest {
 

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/validation/validator/SharedQueueVariableTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/validation/validator/SharedQueueVariableTest.java
@@ -1,0 +1,70 @@
+package com.neotys.neoload.model.v3.validation.validator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.neotys.neoload.model.v3.project.variable.SharedQueueSwapFile;
+import com.neotys.neoload.model.v3.project.variable.SharedQueueVariable;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import org.junit.Test;
+
+public class SharedQueueVariableTest {
+
+	@Test
+	public void validateSwapFileWithoutPath() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("swap_file.path"));
+	}
+
+	@Test
+	public void validateSwapFileDelimiterSize() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("data/my_queue.csv").delimiter("ab").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("swap_file.delimiter"));
+	}
+
+	@Test
+	public void validateQueueSizeMinimum() {
+		final Validator validator = new Validator();
+
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.queueSize(0)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertFalse(validation.isValid());
+		assertTrue(validation.getMessage().get().contains("queue_size"));
+	}
+
+	@Test
+	public void validateFullyValidSharedQueue() {
+		final Validator validator = new Validator();
+
+		final SharedQueueSwapFile swapFile = SharedQueueSwapFile.builder().path("data/my_queue.csv").delimiter(",").build();
+		final SharedQueueVariable sharedQueueVariable = SharedQueueVariable.builder()
+				.name("MySharedQueue")
+				.swapFile(swapFile)
+				.build();
+
+		final Validation validation = validator.validate(sharedQueueVariable, NeoLoad.class);
+		assertTrue(validation.isValid());
+	}
+}

--- a/neoload-project/src/test/resources/test-shared-queue-only-required.json
+++ b/neoload-project/src/test/resources/test-shared-queue-only-required.json
@@ -1,0 +1,1 @@
+{"name":"MyProject","variables":[{"shared_queue":{"name":"MySharedQueue","queue_size":10000,"consumer_timeout":5000}}]}

--- a/neoload-project/src/test/resources/test-shared-queue-only-required.yaml
+++ b/neoload-project/src/test/resources/test-shared-queue-only-required.yaml
@@ -1,0 +1,6 @@
+name: MyProject
+variables:
+- shared_queue:
+    name: MySharedQueue
+    queue_size: 10000
+    consumer_timeout: 5000

--- a/neoload-project/src/test/resources/test-shared-queue-required-and-optional.json
+++ b/neoload-project/src/test/resources/test-shared-queue-required-and-optional.json
@@ -1,0 +1,1 @@
+{"name":"MyProject","variables":[{"shared_queue":{"name":"MySharedQueue","description":"A producer/consumer shared queue","queue_size":5000,"consumer_timeout":2000,"swap_file":{"path":"data/my_queue_swap.csv","delimiter":",","load_from_file":true,"save_to_file":false}}}]}

--- a/neoload-project/src/test/resources/test-shared-queue-required-and-optional.yaml
+++ b/neoload-project/src/test/resources/test-shared-queue-required-and-optional.yaml
@@ -1,0 +1,12 @@
+name: MyProject
+variables:
+- shared_queue:
+    name: MySharedQueue
+    description: A producer/consumer shared queue
+    queue_size: 5000
+    consumer_timeout: 2000
+    swap_file:
+      path: data/my_queue_swap.csv
+      delimiter: ","
+      load_from_file: true
+      save_to_file: false


### PR DESCRIPTION
## Summary
- Add `shared_queue` variable type to the as-code YAML/JSON DSL (producer/consumer queue, optional swap-file persistence)
- Nest swap-file config under `swap_file` (`path`/`delimiter`/`load_from_file`/`save_to_file`) instead of flat fields

## Test plan
- [x] `mvn test` on `neoload-project` (round-trip YAML/JSON read+write, validation tests)