### PR TITLE
LOAD-38606: add debug_logger step to YAML DSL

### DIFF
--- a/neoload-project/doc/v3/debug_logger.md
+++ b/neoload-project/doc/v3/debug_logger.md
@@ -1,0 +1,20 @@
+# Debug Logger
+
+The Debug Logger Action writes a text entry to a log file, for debugging purposes.
+
+#### Available settings
+| Name        | Description                         | Accept variable | Required | Since |
+|:----------- |:------------------------------------|:---------------:|:--------:|:-----:|
+| text        | The text to log                     | &#x2713;         | &#x2713; |       |
+| file        | The path of the log file            | &#x2713;         |    -     |       |
+
+#### Default value
+When `file` is not set, the text is written to `logs/runTimeLog.txt`.
+
+#### Example
+Logging the current user id to a custom log file.
+```yaml
+- debug_logger:
+    text: "Current user: ${user_id}"
+    file: logs/custom.txt
+```

--- a/neoload-project/doc/v3/steps.md
+++ b/neoload-project/doc/v3/steps.md
@@ -18,3 +18,4 @@ All below steps can be in a [transaction](transaction.md) or a [container](conta
 | [variable_modifier](variable_modifier.md)      | 2026.3 |
 | [rendezvous](rendezvous.md)       | 2026.3 |
 | [go_to_next_iteration](go_to_next_iteration.md) | 2026.3 |
+| [debug_logger](debug_logger.md)   | 2026.3 |

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsConstants.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsConstants.java
@@ -16,6 +16,7 @@ class StepsConstants {
     protected static final String FORK = "fork";
     protected static final String VARIABLE_MODIFIER = "variable_modifier";
     protected static final String RENDEZVOUS = "rendezvous";
+    protected static final String DEBUG_LOGGER = "debug_logger";
 
     private StepsConstants() {
         super();

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsDeserializer.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsDeserializer.java
@@ -34,6 +34,7 @@ public class StepsDeserializer extends StdDeserializer<List<Step>> {
 			builder.put(FORK, Fork.class);
 			builder.put(VARIABLE_MODIFIER, VariableModifier.class);
 			builder.put(RENDEZVOUS, Rendezvous.class);
+			builder.put(DEBUG_LOGGER, DebugLogger.class);
     	STEPS = builder.build();
     }
     

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsSerializer.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/binding/serializer/StepsSerializer.java
@@ -31,6 +31,7 @@ public class StepsSerializer extends StdSerializer<List<Step>> {
 		builder.put(ImmutableFork.class, FORK);
 		builder.put(ImmutableVariableModifier.class, VARIABLE_MODIFIER);
 		builder.put(ImmutableRendezvous.class, RENDEZVOUS);
+		builder.put(ImmutableDebugLogger.class, DEBUG_LOGGER);
     	STEPS = builder.build();
     }
 

--- a/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/userpath/DebugLogger.java
+++ b/neoload-project/src/main/java/com/neotys/neoload/model/v3/project/userpath/DebugLogger.java
@@ -1,0 +1,80 @@
+package com.neotys.neoload.model.v3.project.userpath;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.neotys.neoload.model.v3.project.Element;
+import com.neotys.neoload.model.v3.validation.constraints.RequiredCheck;
+import com.neotys.neoload.model.v3.validation.groups.NeoLoad;
+import org.immutables.value.Value;
+
+@JsonInclude(value = Include.NON_EMPTY)
+@JsonPropertyOrder({Element.NAME, Element.DESCRIPTION, DebugLogger.TEXT, DebugLogger.FILE})
+@JsonSerialize(as = ImmutableDebugLogger.class)
+@JsonDeserialize(as = ImmutableDebugLogger.class)
+@Value.Immutable
+@Value.Style(validationMethod = Value.Style.ValidationMethod.NONE)
+// S2097 suppressed: the nested Jackson value-filter classes override equals(Object) to compare the
+// property value (not another filter instance), which is how the CUSTOM value filter selects the default
+// value to omit; a real class check would always be false and defeat the omission.
+@SuppressWarnings("java:S2097")
+public interface DebugLogger extends Step {
+
+	String DEFAULT_NAME = "debug_logger";
+	String DEFAULT_FILE = "logs/runTimeLog.txt";
+	String TEXT = "text";
+	String FILE = "file";
+
+	@JsonInclude(value = Include.CUSTOM, valueFilter = DefaultNameFilter.class)
+	@Value.Default
+	default String getName() {
+		return DEFAULT_NAME;
+	}
+
+	@JsonProperty(TEXT)
+	@RequiredCheck(groups = {NeoLoad.class})
+	String getText();
+
+	@JsonProperty(FILE)
+	@JsonInclude(value = Include.CUSTOM, valueFilter = DefaultFileFilter.class)
+	@Value.Default
+	default String getFile() {
+		return DEFAULT_FILE;
+	}
+
+	// Excludes the default name from serialization: the property is omitted when the filter's
+	// equals(value) returns true.
+	class DefaultNameFilter {
+		@Override
+		public boolean equals(final Object value) {
+			return DEFAULT_NAME.equals(value);
+		}
+
+		@Override
+		public int hashCode() {
+			return DEFAULT_NAME.hashCode();
+		}
+	}
+
+	// Excludes the default file path from serialization: the property is omitted when the filter's
+	// equals(value) returns true.
+	class DefaultFileFilter {
+		@Override
+		public boolean equals(final Object value) {
+			return DEFAULT_FILE.equals(value);
+		}
+
+		@Override
+		public int hashCode() {
+			return DEFAULT_FILE.hashCode();
+		}
+	}
+
+	class Builder extends ImmutableDebugLogger.Builder {}
+	static Builder builder() {
+		return new Builder();
+	}
+}

--- a/neoload-project/src/main/resources/as-code.latest.schema.json
+++ b/neoload-project/src/main/resources/as-code.latest.schema.json
@@ -635,7 +635,8 @@
 								"try_catch": { "$ref": "#/definitions/user_paths/actions/try_catch" },
 								"fork": { "$ref": "#/definitions/user_paths/actions/fork" },
 								"variable_modifier": { "$ref": "#/definitions/user_paths/actions/variable_modifier" },
-								"rendezvous": { "$ref": "#/definitions/user_paths/actions/rendezvous" }
+								"rendezvous": { "$ref": "#/definitions/user_paths/actions/rendezvous" },
+								"debug_logger": { "$ref": "#/definitions/user_paths/actions/debug_logger" }
 							},
 							"additionalProperties": false
 						}
@@ -892,6 +893,17 @@
 					"properties": {
 						"name": { "$ref": "#/definitions/common/text" },
 						"description": { "$ref": "#/definitions/common/text" }
+					},
+					"additionalProperties": false
+				},
+				"debug_logger": {
+					"$id": "#/definitions/user_paths/actions/debug_logger",
+					"title": "Action: Debug Logger",
+					"type": "object",
+					"required": ["text"],
+					"properties": {
+						"text": { "$ref": "#/definitions/common/text" },
+						"file": { "$ref": "#/definitions/common/text" }
 					},
 					"additionalProperties": false
 				}

--- a/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IODebugLoggerTest.java
+++ b/neoload-project/src/test/java/com/neotys/neoload/model/v3/binding/io/IODebugLoggerTest.java
@@ -1,0 +1,56 @@
+package com.neotys.neoload.model.v3.binding.io;
+
+import static com.neotys.neoload.model.v3.binding.io.IOHelper.buildProject;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.neotys.neoload.model.v3.project.Project;
+import com.neotys.neoload.model.v3.project.userpath.DebugLogger;
+import java.io.IOException;
+import org.junit.Test;
+
+public class IODebugLoggerTest extends AbstractIOElementsTest {
+	@Test
+	public void readDebugLoggerOnlyRequired() throws IOException {
+		final Project expectedProject = buildProject(getDebugLoggerOnlyRequired());
+		assertNotNull(expectedProject);
+
+		read("test-debug-logger-only-required", expectedProject);
+	}
+
+	@Test
+	public void readDebugLoggerRequiredAndOptional() throws IOException {
+		final Project expectedProject = buildProject(getDebugLoggerRequiredAndOptional());
+		assertNotNull(expectedProject);
+
+		read("test-debug-logger-required-and-optional", expectedProject);
+	}
+
+	@Test
+	public void writeDebugLoggerOnlyRequired() throws IOException {
+		final Project expectedProject = buildProject(getDebugLoggerOnlyRequired());
+		assertNotNull(expectedProject);
+
+		write("test-debug-logger-only-required", expectedProject);
+	}
+
+	@Test
+	public void writeDebugLoggerRequiredAndOptional() throws IOException {
+		final Project expectedProject = buildProject(getDebugLoggerRequiredAndOptional());
+		assertNotNull(expectedProject);
+
+		write("test-debug-logger-required-and-optional", expectedProject);
+	}
+
+	private DebugLogger getDebugLoggerOnlyRequired() {
+		return DebugLogger.builder()
+				.text("Current user: ${user_id}")
+				.build();
+	}
+
+	private DebugLogger getDebugLoggerRequiredAndOptional() {
+		return DebugLogger.builder()
+				.text("Current user: ${user_id}")
+				.file("logs/custom.txt")
+				.build();
+	}
+}

--- a/neoload-project/src/test/resources/test-debug-logger-only-required.json
+++ b/neoload-project/src/test/resources/test-debug-logger-only-required.json
@@ -1,0 +1,1 @@
+{"name":"MyProject","user_paths":[{"name":"MyUserPath","actions":{"steps":[{"debug_logger":{"text":"Current user: ${user_id}"}}]}}]}

--- a/neoload-project/src/test/resources/test-debug-logger-only-required.yaml
+++ b/neoload-project/src/test/resources/test-debug-logger-only-required.yaml
@@ -1,0 +1,7 @@
+name: MyProject
+user_paths:
+- name: MyUserPath
+  actions:
+    steps:
+    - debug_logger:
+        text: "Current user: ${user_id}"

--- a/neoload-project/src/test/resources/test-debug-logger-required-and-optional.json
+++ b/neoload-project/src/test/resources/test-debug-logger-required-and-optional.json
@@ -1,0 +1,1 @@
+{"name":"MyProject","user_paths":[{"name":"MyUserPath","actions":{"steps":[{"debug_logger":{"text":"Current user: ${user_id}","file":"logs/custom.txt"}}]}}]}

--- a/neoload-project/src/test/resources/test-debug-logger-required-and-optional.yaml
+++ b/neoload-project/src/test/resources/test-debug-logger-required-and-optional.yaml
@@ -1,0 +1,8 @@
+name: MyProject
+user_paths:
+- name: MyUserPath
+  actions:
+    steps:
+    - debug_logger:
+        text: "Current user: ${user_id}"
+        file: logs/custom.txt


### PR DESCRIPTION
## Summary

- Complete `debug_logger` YAML DSL support in neoload-project models (model, schema, serializer/deserializer registration, docs).
- Fixture pair + read/write tests for required-only and required-plus-optional shapes.
- Plan: `.claude/handoffs/LOAD-38606.md`. Jira AC lines for the neoload-root forward/reverse converters are deliberately out of scope here and stay open for a follow-up.

## Test plan

- `mvn -pl neoload-project test -Dtest=IODebugLoggerTest`
- Round-trip read -> write -> read yields an equal `Project`; JSON schema still validates.