### PR TITLE
Add neoload-project-model without Jackson/Antlr transitive deps

### DIFF
--- a/neoload-project-model/pom.xml
+++ b/neoload-project-model/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>neoload-models</artifactId>
+        <groupId>com.neotys.neoload</groupId>
+        <version>3.3.8-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>neoload-project-model</artifactId>
+    <name>neoload-project-model</name>
+    <description>
+        Wrapper around neoload-project that excludes Jackson and antlr4-runtime transitive dependencies.
+        Use this artifact for model/Gson-only consumers. Use neoload-project when Jackson IO/binding is required.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.neotys.neoload</groupId>
+            <artifactId>neoload-project</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.antlr</groupId>
+                    <artifactId>antlr4-runtime</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
 	<version>3.3.8-SNAPSHOT</version>
 	<modules>
 		<module>neoload-project</module>
+		<module>neoload-project-model</module>
 		<module>neoload-writer</module>
 		<module>models-readers</module>
 		<module>global-tests</module>
@@ -109,6 +110,11 @@
 			<dependency>
 				<groupId>com.neotys.neoload</groupId>
 				<artifactId>neoload-project</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.neotys.neoload</groupId>
+				<artifactId>neoload-project-model</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
## Summary
- Add `neoload-project-model`: thin wrapper around `neoload-project` that excludes Jackson and `antlr4-runtime`
- Wire the module into the reactor and `dependencyManagement`
- Leave `neoload-project` unchanged so IO/binding consumers keep one dependency with the full stack

## Usage
- Models / Gson only → `neoload-project-model`
- IO / Jackson binding → `neoload-project`
- Service needing both (e.g. verticle → API + service with `neoload-project`): keep a direct `neoload-project` on the service so Jackson is not dropped by mediation

## Test plan
- [x] `mvn -pl neoload-project-model dependency:tree` has `neoload-project`, no Jackson/Antlr
- [x] `neoload-project` tree still includes Jackson
- [x] Dual direct deps with model listed first still keep Jackson
- [ ] CI reactor build

Made with [Cursor](https://cursor.com)