### PR TITLE
chore: bump snapshot version to 3.4.0-SNAPSHOT

### DIFF
--- a/global-tests/pom.xml
+++ b/global-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neoload-models</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/models-readers/common-reader/pom.xml
+++ b/models-readers/common-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>models-readers</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/models-readers/jmeter-reader/pom.xml
+++ b/models-readers/jmeter-reader/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>models-readers</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/models-readers/loadrunner-reader/pom.xml
+++ b/models-readers/loadrunner-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>models-readers</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/models-readers/pom.xml
+++ b/models-readers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neoload-models</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neoload-project/pom.xml
+++ b/neoload-project/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neoload-models</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/neoload-writer/pom.xml
+++ b/neoload-writer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>neoload-models</artifactId>
         <groupId>com.neotys.neoload</groupId>
-        <version>3.3.8-SNAPSHOT</version>
+        <version>3.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.neotys.neoload</groupId>
 	<artifactId>neoload-models</artifactId>
-	<version>3.3.8-SNAPSHOT</version>
+	<version>3.4.0-SNAPSHOT</version>
 	<modules>
 		<module>neoload-project</module>
 		<module>neoload-writer</module>


### PR DESCRIPTION
## Summary
- Bump snapshot version from 3.3.8-SNAPSHOT to 3.4.0-SNAPSHOT across all poms

## Test plan
- [ ] Build passes with new version