### PR TITLE
Bump Jackson, Immutables, and related dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,27 +78,27 @@
 		<project.scm.id>git</project.scm.id>
 		<encoding>UTF-8</encoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<immutables.version>2.9.3</immutables.version>
-		<gson.version>2.10.1</gson.version>
-		<commons-configuration2.version>2.11.0</commons-configuration2.version>
-		<commons-io.version>2.17.0</commons-io.version>
-		<commons-lang3.version>3.4</commons-lang3.version>
-		<commons-collections4.version>4.4</commons-collections4.version>
+		<immutables.version>2.12.2</immutables.version>
+		<gson.version>2.14.0</gson.version>
+		<commons-configuration2.version>2.15.1</commons-configuration2.version>
+		<commons-io.version>2.22.0</commons-io.version>
+		<commons-lang3.version>3.20.0</commons-lang3.version>
+		<commons-collections4.version>4.6.0</commons-collections4.version>
 		<jsr305.version>3.0.1</jsr305.version>
 		<guava.version>32.0.1-jre</guava.version>
-		<jackson.version>2.16.1</jackson.version>
+		<jackson.version>2.21.6</jackson.version>
 		<antlr.version>4.7</antlr.version>
-		<slf4j.version>2.0.7</slf4j.version>
-		<logback.classic.version>1.5.16</logback.classic.version>
+		<slf4j.version>2.0.18</slf4j.version>
+		<logback.classic.version>1.5.38</logback.classic.version>
 		<gpg.executable>/usr/bin/gpg</gpg.executable>
 		<!--suppress UnresolvedMavenProperty -->
 		<gpg.passphrase>${env.PGP_PASSPHRASE}</gpg.passphrase>
-		<jacoco.version>0.8.12</jacoco.version>
+		<jacoco.version>0.8.15</jacoco.version>
     	<validation-api.version>2.0.2</validation-api.version>
     	<hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
     	<glassfish.jakarta.el.version>3.0.4</glassfish.jakarta.el.version>
 		<jmeter.version>5.6.3</jmeter.version>
-		<assertj-core.version>3.17.1</assertj-core.version>
+		<assertj-core.version>3.27.7</assertj-core.version>
 		<mockito.version>5.23.0</mockito.version>
 	</properties>
 


### PR DESCRIPTION
## Summary
- `jackson` `2.16.1` → `2.21.6` (2.21 LTS)
- `immutables` `2.9.3` → `2.12.2`
- Also refresh: Gson, Commons (lang3/io/collections4/configuration2), SLF4J, Logback, AssertJ, JaCoCo
- **Guava stays at `32.0.1-jre`** (Guava 33 drops `javax.annotation` and breaks `@Nullable` compilation)

## Test plan
- [x] `mvn clean test` on full reactor

Made with [Cursor](https://cursor.com)