### PR TITLE
fix release - add a name matching each artifactId to modules

### DIFF
--- a/global-tests/pom.xml
+++ b/global-tests/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>global-tests</artifactId>
+    <name>global-tests</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/models-readers/common-reader/pom.xml
+++ b/models-readers/common-reader/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>common-reader</artifactId>
+    <name>common-reader</name>
 
     <dependencies>
 		<dependency>

--- a/models-readers/jmeter-reader/pom.xml
+++ b/models-readers/jmeter-reader/pom.xml
@@ -2,6 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jmeter-reader</artifactId>
+    <name>jmeter-reader</name>
     <packaging>jar</packaging>
 
     <parent>

--- a/models-readers/loadrunner-reader/pom.xml
+++ b/models-readers/loadrunner-reader/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>loadrunner-reader</artifactId>
+    <name>loadrunner-reader</name>
 
     <dependencies>
 		<dependency>

--- a/models-readers/pom.xml
+++ b/models-readers/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>models-readers</artifactId>
+    <name>models-readers</name>
     <packaging>pom</packaging>
     <modules>
         <module>common-reader</module>

--- a/neoload-project/pom.xml
+++ b/neoload-project/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>neoload-project</artifactId>
+    <name>neoload-project</name>
 
     <dependencies>
         <dependency>

--- a/neoload-writer/pom.xml
+++ b/neoload-writer/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>neoload-writer</artifactId>
+    <name>neoload-writer</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The release failed Maven Central validation, not GPG, credentials, or the upload itself. The bundle was uploaded (deploymentId: 081c1d36-8184-4e03-8627-a9973e506961) and then rejected.

Cause: Central requires a <name> on every published POM. Maven does not inherit <name> from the parent (unlike description, url, licenses, developers, and scm). That is why only this field failed, and why last year’s OSSRH release could succeed without the new plugin.

Root pom.xml has <name>neoload-models</name>. Only neoload-project-model also has a name, so it was not in the error list.